### PR TITLE
[APB-4548][MP] removing authentication on the get agent suspension endpoint

### DIFF
--- a/app/uk/gov/hmrc/agentsexternalstubs/controllers/AgentSuspensionController.scala
+++ b/app/uk/gov/hmrc/agentsexternalstubs/controllers/AgentSuspensionController.scala
@@ -4,6 +4,7 @@ import javax.inject.Inject
 import play.api.libs.json.{Json, OFormat}
 import play.api.mvc.{Action, AnyContent, ControllerComponents}
 import uk.gov.hmrc.agentmtdidentifiers.model.Arn
+import uk.gov.hmrc.agentsexternalstubs.models.{EnrolmentKey, Identifier}
 import uk.gov.hmrc.agentsexternalstubs.services.{AuthenticationService, UsersService}
 import uk.gov.hmrc.play.bootstrap.controller.BackendController
 
@@ -17,18 +18,18 @@ class AgentSuspensionController @Inject()(
 
   def getSuspensionStatus(arn: Arn): Action[AnyContent] = Action.async { implicit request =>
     withCurrentSession { session =>
-      usersService.findByUserId(session.userId, session.planetId).flatMap {
-        case None => Future successful notFound("USER_NOT_FOUND")
-        case Some(user)
-            if user.principalEnrolments.exists(e => e.identifiers.getOrElse(Seq()).exists(_.value == arn.value)) =>
-          user.suspendedServices match {
-            case None     => Future successful Ok(Json.toJson(AgentSuspensionResponse("NotSuspended")))
-            case Some(ss) => Future successful Ok(Json.toJson(AgentSuspensionResponse("Suspended", Some(ss))))
-          }
-        case Some(user) if user.affinityGroup.contains("Agent") =>
-          Future successful Unauthorized("arn does not match that of logged in user")
-        case Some(_) => Future successful Unauthorized("user is not an agent")
-      }
+      usersService
+        .findByPrincipalEnrolmentKey(
+          EnrolmentKey("HMRC-AS-AGENT", Seq(Identifier("AgentReferenceNumber", arn.value))),
+          session.planetId)
+        .flatMap {
+          case None => Future successful notFound("USER_NOT_FOUND")
+          case Some(user) =>
+            user.suspendedServices match {
+              case None     => Future successful Ok(Json.toJson(AgentSuspensionResponse("NotSuspended")))
+              case Some(ss) => Future successful Ok(Json.toJson(AgentSuspensionResponse("Suspended", Some(ss))))
+            }
+        }
     }(SessionRecordNotFound)
   }
 }

--- a/it/uk/gov/hmrc/agentsexternalstubs/controllers/AgentSuspensionControllerISpec.scala
+++ b/it/uk/gov/hmrc/agentsexternalstubs/controllers/AgentSuspensionControllerISpec.scala
@@ -22,7 +22,7 @@ class AgentSuspensionControllerISpec extends ServerBaseISpec with TestRequests {
           .copy(
             userId = session.userId,
             principalEnrolments =
-              Seq(Enrolment("HMRC-AS-AGENT", Some(Seq(Identifier("AgetReferenceNumber", "TARN0000001"))))))
+              Seq(Enrolment("HMRC-AS-AGENT", Some(Seq(Identifier("AgentReferenceNumber", "TARN0000001"))))))
         await(repo.update(user, session.planetId))
         val result = AgentSuspensionStub.getSuspensionStatus(Arn("TARN0000001"))
 
@@ -38,7 +38,7 @@ class AgentSuspensionControllerISpec extends ServerBaseISpec with TestRequests {
             userId = session.userId,
             suspendedServices = Some(Set("HMRC-MTD-IT", "HMRC-MTD-VAT")),
             principalEnrolments =
-              Seq(Enrolment("HMRC-AS-AGENT", Some(Seq(Identifier("AgetReferenceNumber", "TARN0000001")))))
+              Seq(Enrolment("HMRC-AS-AGENT", Some(Seq(Identifier("AgentReferenceNumber", "TARN0000001")))))
           )
         await(repo.update(user, session.planetId))
         val result = AgentSuspensionStub.getSuspensionStatus(Arn("TARN0000001"))
@@ -46,33 +46,6 @@ class AgentSuspensionControllerISpec extends ServerBaseISpec with TestRequests {
         result.status shouldBe 200
         result.json shouldBe Json.parse(
           """{"status": "Suspended", "suspendedServices": ["HMRC-MTD-IT", "HMRC-MTD-VAT"]}""")
-      }
-
-      "return Unauthorized when the arn does not match that of the logged in user" in {
-        implicit val session: AuthenticatedSession = SignIn.signInAndGetSession()
-        val user = UserGenerator
-          .agent()
-          .copy(
-            userId = session.userId,
-            suspendedServices = Some(Set("HMRC-MTD-IT", "HMRC-MTD-VAT")),
-            principalEnrolments =
-              Seq(Enrolment("HMRC-AS-AGENT", Some(Seq(Identifier("AgetReferenceNumber", "TARN0000001")))))
-          )
-        await(repo.update(user, session.planetId))
-        val result = AgentSuspensionStub.getSuspensionStatus(Arn("ZARN0000001"))
-
-        result.status shouldBe 401
-        result.body shouldBe "arn does not match that of logged in user"
-      }
-
-      "return Unauthorized when the logged in user is not an agent" in {
-        implicit val session: AuthenticatedSession = SignIn.signInAndGetSession()
-        val user = UserGenerator.individual(userId = session.userId)
-        await(repo.update(user, session.planetId))
-        val result = AgentSuspensionStub.getSuspensionStatus(Arn("TARN0000001"))
-
-        result.status shouldBe 401
-        result.body shouldBe "user is not an agent"
       }
 
       "return not found when user record cannot be found" in {


### PR DESCRIPTION
After realising we need to get the status of an agent using the arn in both the client and stride authenticated journeys!