### PR TITLE
Allow non-admin members of an organisation to be authorised for shared group enrolments, refactor ES11

### DIFF
--- a/app/uk/gov/hmrc/agentsexternalstubs/controllers/AuthStubController.scala
+++ b/app/uk/gov/hmrc/agentsexternalstubs/controllers/AuthStubController.scala
@@ -72,6 +72,7 @@ class AuthStubController @Inject() (
                                                   Authorise.prepareAuthoriseResponse(
                                                     FullAuthoriseContext(
                                                       user,
+                                                      usersService,
                                                       authenticatedSession,
                                                       authoriseRequest,
                                                       agentAccessControlConnector

--- a/app/uk/gov/hmrc/agentsexternalstubs/services/UsersService.scala
+++ b/app/uk/gov/hmrc/agentsexternalstubs/services/UsersService.scala
@@ -137,7 +137,7 @@ class UsersService @Inject() (
                            _       <- usersRepository.update(refined, planetId)
                            _       <- updateKnownFacts(refined, planetId)
                            _       <- userRecordsService.syncUserToRecords(syncRecordId(refined, planetId))(refined)
-                           _ = AuthorisationCache.updateResultsFor(refined, planetId)
+                           _ = AuthorisationCache.updateResultsFor(refined, UsersService.this, planetId)
                          } yield refined
                          else Future.successful(existingUser)
                        case None => Future.failed(new NotFoundException(s"User $userId not found"))


### PR DESCRIPTION
This PR adds missing functionality in AES enrolment and authorization handling. 

Enrolments are allocated to groups, but as AES has no separate group entity and the enrolment is always allocated to the unique admin user of the group. This setup works perfectly well for a majority of simple cases but falls short when dealing with multi-user organisations. The solution applied here is to look for both user's own enrolments and group-level enrolments during the authorisation process.

Subsequently, ES11 implementation changes to do only necessary eligibility checks and nothing more, as the enrolment being assigned has been already allocated to the group.