### PR TITLE
Fixes creation of customerDetails before storing PPTSubscriptionDisplayRecord

### DIFF
--- a/app/uk/gov/hmrc/agentsexternalstubs/models/PPTSubscriptionDisplayRecord.scala
+++ b/app/uk/gov/hmrc/agentsexternalstubs/models/PPTSubscriptionDisplayRecord.scala
@@ -19,6 +19,7 @@ package uk.gov.hmrc.agentsexternalstubs.models
 import org.scalacheck.{Arbitrary, Gen}
 import play.api.libs.json._
 import uk.gov.hmrc.agentsexternalstubs.models.PPTSubscriptionDisplayRecord._
+import uk.gov.hmrc.agentsexternalstubs.models.User.AG
 
 /** ----------------------------------------------------------------------------
   * THIS FILE HAS BEEN GENERATED - DO NOT MODIFY IT, CHANGE THE SCHEMA IF NEEDED
@@ -368,7 +369,11 @@ object PPTSubscriptionDisplayRecord extends RecordUtils[PPTSubscriptionDisplayRe
 
       val individualDetailsOrOrganisationDetailsAlternativeSanitizer: Update = seed =>
         entity =>
-          if (entity.individualDetails.isDefined) individualDetailsCompoundSanitizer(seed)(entity)
+          if (entity.customerType == AG.Individual && entity.organisationDetails.isEmpty)
+            individualDetailsCompoundSanitizer(seed)(entity)
+          else if (entity.customerType == AG.Organisation && entity.individualDetails.isEmpty)
+            organisationDetailsCompoundSanitizer(seed)(entity)
+          else if (entity.individualDetails.isDefined) individualDetailsCompoundSanitizer(seed)(entity)
           else if (entity.organisationDetails.isDefined) organisationDetailsCompoundSanitizer(seed)(entity)
           else
             Generator.get(Gen.chooseNum(0, 1))(seed) match {

--- a/test/uk/gov/hmrc/agentsexternalstubs/models/PPTSubscriptionDisplayRecordSpec.scala
+++ b/test/uk/gov/hmrc/agentsexternalstubs/models/PPTSubscriptionDisplayRecordSpec.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2022 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentsexternalstubs.models
+
+import org.scalatest.Inspectors
+import uk.gov.hmrc.agentsexternalstubs.models.PPTSubscriptionDisplayRecord.LegalEntityDetails.CustomerDetails
+import uk.gov.hmrc.agentsexternalstubs.support.UnitSpec
+
+class PPTSubscriptionDisplayRecordSpec extends UnitSpec {
+
+  val seeds = "foeba".permutations.toSeq
+
+  "CustomerDetails" should {
+
+    "be generated correctly" in {
+      Inspectors.forAll(seeds) { seed: String =>
+        val entity = CustomerDetails.generate(seed)
+        entity.customerType match {
+          case "Individual" =>
+            entity.individualDetails shouldBe defined
+            entity.organisationDetails shouldBe None
+          case "Organisation" =>
+            entity.individualDetails shouldBe None
+            entity.organisationDetails shouldBe defined
+          case _ => fail(s"Unknown customer type ${entity.customerType}")
+        }
+      }
+    }
+
+  }
+
+}


### PR DESCRIPTION

Data for affinity groups Individual and Organisation are not being correctly created for PPT. The following are examples:

`"customerDetails": {
"customerType": "Organisation",
"individualDetails": {
"firstName": "John",
"lastName": "Doe"
}
}`

`"customerDetails": {
"customerType": "Individual",
"organisationDetails": {
"organisationName": "Agency"
}
}`

This PR fixes this.