### PR TITLE
Shortens planetId in perf datagen

### DIFF
--- a/app/uk/gov/hmrc/agentsexternalstubs/controllers/datagen/AgencyDataAssembler.scala
+++ b/app/uk/gov/hmrc/agentsexternalstubs/controllers/datagen/AgencyDataAssembler.scala
@@ -38,7 +38,7 @@ class AgencyDataAssembler extends Logging {
     clientsPerAgent: Int,
     teamMembersPerAgent: Int
   ): AgencyCreationPayload = {
-    val planetId = f"perf-test-planet-$indexAgency%03d"
+    val planetId = f"p-$indexAgency%03d"
 
     logger.info(s"Assembling data for '$planetId'. Can take a while...")
 


### PR DESCRIPTION
- Helps reduce document size as planet id is used extensively in DB indexing key values