### PR TITLE
build-fix [CS] disable JUnitXmlReportPlugin

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,4 @@
 import sbt._
-import uk.gov.hmrc.SbtAutoBuildPlugin
 
 ThisBuild / libraryDependencySchemes += "org.typelevel" %% "cats-core" % "always"
 
@@ -14,28 +13,6 @@ lazy val scoverageSettings = {
     Test / parallelExecution := false
   )
 }
-
-lazy val compileDeps = Seq(
-  ws,
-  "uk.gov.hmrc"          %% "bootstrap-backend-play-28" % "7.14.0",
-  "uk.gov.hmrc.mongo"    %% "hmrc-mongo-play-28"        % "1.0.0",
-  "uk.gov.hmrc"          %% "agent-mtd-identifiers"     % "0.56.0-play-28",
-  "com.kenshoo"          %% "metrics-play"              % "2.7.3_0.8.2",
-  "com.github.blemale"   %% "scaffeine"                 % "4.0.1",
-  "org.typelevel"        %% "cats-core"                 % "2.6.1",
-  "uk.gov.hmrc"          %% "stub-data-generator"       % "1.0.0",
-  "io.github.wolfendale" %% "scalacheck-gen-regexp"     % "0.1.3",
-  "com.typesafe.play"    %% "play-json"                 % "2.9.2"
-)
-
-def testDeps(scope: String) = Seq(
-  "org.scalatestplus.play" %% "scalatestplus-play" % "5.1.0"    % scope,
-  "org.scalatestplus"      %% "mockito-3-12"       % "3.2.10.0" % scope,
-  "uk.gov.hmrc.mongo" %% "hmrc-mongo-test-play-28" % "1.0.0"   % scope,
-  "com.github.tomakehurst"  % "wiremock-jre8"      % "2.26.1"   % scope,
-  "com.github.pathikrit"   %% "better-files"       % "3.9.1"    % scope,
-  "com.vladsch.flexmark"    % "flexmark-all"       % "0.35.10"  % scope
-)
 
 val jettyVersion = "9.2.24.v20180105"
 
@@ -75,7 +52,7 @@ lazy val root = (project in file("."))
     resolvers ++= Seq(
       Resolver.typesafeRepo("releases"),
     ),
-    libraryDependencies ++= compileDeps ++ testDeps("test") ++ testDeps("it"),
+    libraryDependencies ++= AppDependencies.compile ++ AppDependencies.test,
     libraryDependencies ++= Seq(
       compilerPlugin("com.github.ghik" % "silencer-plugin" % "1.7.7" cross CrossVersion.full),
       "com.github.ghik" % "silencer-lib" % "1.7.7" % Provided cross CrossVersion.full
@@ -97,6 +74,7 @@ lazy val root = (project in file("."))
     IntegrationTest / parallelExecution := false,
     IntegrationTest / scalafmtOnCompile := true
 )
-  .enablePlugins(play.sbt.PlayScala, SbtAutoBuildPlugin, SbtGitVersioning, SbtDistributablesPlugin)
+  .enablePlugins(play.sbt.PlayScala, SbtDistributablesPlugin)
+  .disablePlugins(JUnitXmlReportPlugin)  //To prevent https://github.com/scalatest/scalatest/issues/1427
 
 inConfig(IntegrationTest)(org.scalafmt.sbt.ScalafmtPlugin.scalafmtConfigSettings)

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -1,0 +1,31 @@
+import play.sbt.PlayImport.ws
+import sbt._
+
+object AppDependencies {
+
+  private val bootstrapVer = "7.14.0"
+  private val mongoVer = "1.0.0"
+  
+  lazy val compile = Seq(
+    ws,
+    "uk.gov.hmrc"          %% "bootstrap-backend-play-28" % bootstrapVer,
+    "uk.gov.hmrc.mongo"    %% "hmrc-mongo-play-28"        % mongoVer,
+    "uk.gov.hmrc"          %% "agent-mtd-identifiers"     % "1.2.0",
+    "com.kenshoo"          %% "metrics-play"              % "2.7.3_0.8.2",
+    "com.github.blemale"   %% "scaffeine"                 % "4.0.1",
+    "org.typelevel"        %% "cats-core"                 % "2.6.1",
+    "uk.gov.hmrc"          %% "stub-data-generator"       % "1.0.0",
+    "io.github.wolfendale" %% "scalacheck-gen-regexp"     % "0.1.3",
+    "com.typesafe.play"    %% "play-json"                 % "2.9.2"
+  )
+  lazy val test = Seq(
+    "org.scalatestplus.play" %% "scalatestplus-play"        % "5.1.0"      % "test, it",
+    "org.scalatestplus"      %% "mockito-3-12"              % "3.2.10.0"   % "test, it",
+    "uk.gov.hmrc.mongo"      %% "hmrc-mongo-test-play-28"   % mongoVer     % "test, it",
+    "uk.gov.hmrc"            %% "bootstrap-test-play-28"    % bootstrapVer % "test, it",
+    "com.github.tomakehurst"  % "wiremock-jre8"             % "2.26.1"     % "test, it",
+    "com.github.pathikrit"   %% "better-files"              % "3.9.1"      % "test, it",
+    "com.vladsch.flexmark"    % "flexmark-all"              % "0.35.10"    % "test, it"
+  )
+
+}

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -3,7 +3,7 @@ resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.9.0")
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.18")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.19")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.2.0")
 


### PR DESCRIPTION
Should prevent unstable builds due to unable to read test reports