### PR TITLE
APB-7219 [CS] add display CBC API (draft)

### DIFF
--- a/app/uk/gov/hmrc/agentsexternalstubs/controllers/CountryByCountryController.scala
+++ b/app/uk/gov/hmrc/agentsexternalstubs/controllers/CountryByCountryController.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentsexternalstubs.controllers
+
+import play.api.libs.json.{JsValue, Json}
+import play.api.mvc.{Action, ControllerComponents, Result}
+import uk.gov.hmrc.agentmtdidentifiers.model.CbcId
+import uk.gov.hmrc.agentsexternalstubs.models.{DisplaySubscriptionForCbCRequestPayload, Generator}
+import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+import scala.io.Source
+
+@Singleton
+class CountryByCountryController @Inject() (cc: ControllerComponents)(implicit ec: ExecutionContext)
+    extends BackendController(cc) with HttpHelpers {
+
+  def generateCbcRecord(): Unit = {}
+
+  /** MTDP -> EIS -> ETMP
+    */
+  def displaySubscriptionForCbC: Action[JsValue] = Action.async(parse.tolerantJson) { implicit request =>
+    withPayload[DisplaySubscriptionForCbCRequestPayload] { payload =>
+      if (CbcId.isValid(payload.requestDetail.IDNumber)) {
+        response(payload.requestDetail.IDNumber)
+      } else {
+        Future.successful(BadRequest("invalid cbcId"))
+      }
+    }
+  }
+
+  private def response(cbcId: String): Future[Result] =
+    findResource(s"/resources/country-by-country/response-template.json")
+      .map(
+        _.map(
+          _.replaceAll("%%%COUNTRY_BY_COUNTRY_ID%%%", cbcId)
+            .replaceAll("%%%TRADING_NAME%%%", Generator.company.sample.get)
+        )
+      )
+      .map(_.fold[Result](NotFound)(jsonStr => Ok(Json.parse(jsonStr))))
+
+  private def findResource(resourcePath: String): Future[Option[String]] = Future {
+    Option(getClass.getResourceAsStream(resourcePath))
+      .map(Source.fromInputStream(_).mkString)
+  }
+
+}

--- a/app/uk/gov/hmrc/agentsexternalstubs/controllers/CountryByCountryController.scala
+++ b/app/uk/gov/hmrc/agentsexternalstubs/controllers/CountryByCountryController.scala
@@ -30,8 +30,6 @@ import scala.io.Source
 class CountryByCountryController @Inject() (cc: ControllerComponents)(implicit ec: ExecutionContext)
     extends BackendController(cc) with HttpHelpers {
 
-  def generateCbcRecord(): Unit = {}
-
   /** MTDP -> EIS -> ETMP
     */
   def displaySubscriptionForCbC: Action[JsValue] = Action.async(parse.tolerantJson) { implicit request =>

--- a/app/uk/gov/hmrc/agentsexternalstubs/controllers/CountryByCountryController.scala
+++ b/app/uk/gov/hmrc/agentsexternalstubs/controllers/CountryByCountryController.scala
@@ -36,8 +36,8 @@ class CountryByCountryController @Inject() (cc: ControllerComponents)(implicit e
     */
   def displaySubscriptionForCbC: Action[JsValue] = Action.async(parse.tolerantJson) { implicit request =>
     withPayload[DisplaySubscriptionForCbCRequestPayload] { payload =>
-      if (CbcId.isValid(payload.requestDetail.IDNumber)) {
-        response(payload.requestDetail.IDNumber)
+      if (CbcId.isValid(payload.displaySubscriptionForCbCRequest.requestDetail.IDNumber)) {
+        response(payload.displaySubscriptionForCbCRequest.requestDetail.IDNumber)
       } else {
         Future.successful(BadRequest("invalid cbcId"))
       }
@@ -45,7 +45,7 @@ class CountryByCountryController @Inject() (cc: ControllerComponents)(implicit e
   }
 
   private def response(cbcId: String): Future[Result] =
-    findResource(s"/resources/country-by-country/response-template.json")
+    findResource(s"/resources/country-by-country/full-response-template.json")
       .map(
         _.map(
           _.replaceAll("%%%COUNTRY_BY_COUNTRY_ID%%%", cbcId)

--- a/app/uk/gov/hmrc/agentsexternalstubs/models/DisplaySubscriptionForCbC.scala
+++ b/app/uk/gov/hmrc/agentsexternalstubs/models/DisplaySubscriptionForCbC.scala
@@ -16,11 +16,7 @@
 
 package uk.gov.hmrc.agentsexternalstubs.models
 
-import org.scalacheck.Gen
-import play.api.libs.json.{Format, Json, OFormat}
-import uk.gov.hmrc.agentmtdidentifiers.model.CbcId
-import uk.gov.hmrc.agentsexternalstubs.models
-import uk.gov.hmrc.agentsexternalstubs.models.Validator.Validator
+import play.api.libs.json.{Json, OFormat}
 
 import java.time.LocalDateTime
 
@@ -83,36 +79,6 @@ object DisplaySubscriptionForCbCRequestPayload {
 
 // ************************************ //
 
-//   JSON sample response
-//  {
-//    "displaySubscriptionForCbCResponse": {
-//      "responseCommon": {
-//        "status": "OK",
-//        "processingDate": "2020-08-09T11:23:45Z"
-//      },
-//      "responseDetail": {
-//        "subscriptionID": "yu789428932",
-//        "tradingName": "Tools for Traders",
-//        "isGBUser": true,
-//        "primaryContact": [
-//          {
-//            "email": "Tim@toolsfortraders.com",
-//            "phone": "078803423883",
-//            "mobile": "078803423883",
-//            "individual": {
-//            "lastName": "Taylor",
-//            "firstName": "Tim"}
-//          }
-//        ],
-//        "secondaryContact": [
-//          {
-//            "email": "contact@toolsfortraders.com",
-//            "organisation": {"organisationName": "Tools for Traders Limited"}
-//          }
-//        ]
-//      }
-//    }
-//  }
 case class IndividualContact(
   firstName: String,
   lastName: String,
@@ -174,36 +140,3 @@ case class DisplaySubscriptionForCbC(displaySubscriptionForCbCResponse: DisplayS
 object DisplaySubscriptionForCbC {
   implicit val format: OFormat[DisplaySubscriptionForCbC] = Json.format[DisplaySubscriptionForCbC]
 }
-
-// TODO: Generate a DisplaySubscriptionForCbCRecord
-//
-// Seed
-//  cbcId: CbcId = "YUDD789429",
-//  ?? requestParameters: Option[Map[String, String]]
-//
-// Outputs Uk or nonUK, with or without trading name - but contacts seem mandatory?
-
-//case class CbcSubscriptionDisplayRecord(
-//                                         id: Option[String] = None,
-//                                         cbcId: String,
-//                                         tradingName: Option[String],
-//                                         isGBUser: Boolean
-//                                       ) extends Record {
-//
-//  override def uniqueKey: Option[String] = Option(cbcId).map(CbcSubscriptionDisplayRecord.uniqueKey)
-//  override def lookupKeys: Seq[String] =
-//    Seq(Option(cbcId).map(CbcSubscriptionDisplayRecord.cbcIdKey)).collect { case Some(x) => x }
-//  override def withId(id: Option[String]): CbcSubscriptionDisplayRecord = copy(id = id)
-//
-//  def withCbcId(cbcId: String): CbcSubscriptionDisplayRecord = copy(cbcId = cbcId)
-//
-//}
-//
-//object CbcSubscriptionDisplayRecord extends RecordUtils[CbcSubscriptionDisplayRecord] {
-//  def uniqueKey(key: String): String = s"""cbcId:${key.toUpperCase}"""
-//  def CbcIdKey(key: String): String = s"""cbcId:${key.toUpperCase}"""
-//
-//  override val gen: Gen[CbcSubscriptionDisplayRecord] = _
-//  override val validate: Validator[CbcSubscriptionDisplayRecord] = _
-//  override val sanitizers: Seq[models.CbcSubscriptionDisplayRecord.Update] = _
-//}

--- a/app/uk/gov/hmrc/agentsexternalstubs/models/DisplaySubscriptionForCbC.scala
+++ b/app/uk/gov/hmrc/agentsexternalstubs/models/DisplaySubscriptionForCbC.scala
@@ -1,0 +1,205 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentsexternalstubs.models
+
+import org.scalacheck.Gen
+import play.api.libs.json.{Format, Json, OFormat}
+import uk.gov.hmrc.agentmtdidentifiers.model.CbcId
+import uk.gov.hmrc.agentsexternalstubs.models
+import uk.gov.hmrc.agentsexternalstubs.models.Validator.Validator
+
+import java.time.LocalDateTime
+
+//  JSON sample for request to EIS
+//  { "displaySubscriptionForCbCRequest":{
+//      "requestCommon": {
+//      "regime": "CbC",
+//      "conversationID": "d3937a26-a4ec-4f11-bd8d-a93fc0265701",
+//      "receiptDate": "2020-09-15T09:38:00Z",
+//      "acknowledgementReference": "8493893huer3ruihuow",
+//      "originatingSystem": "MDTP",
+//      "requestParameters": [
+//        {
+//          "paramName": "param name",
+//          "paramValue": "param value"
+//        }
+//      ]
+//    },
+//    "requestDetail": {
+//      "IDType": "CbC",
+//      "IDNumber": "YUDD789429"
+//    } }
+//  }
+
+case class CbCRequestCommon(
+  regime: String = "CbC",
+  conversationID: String = "d3937a26-a4ec-4f11-bd8d-a93fc0265701",
+  receiptDate: LocalDateTime,
+  acknowledgementReference: String = "8493893huer3ruihuow",
+  originatingSystem: String = "MDTP",
+  requestParameters: Option[Map[String, String]]
+)
+
+object CbCRequestCommon {
+  implicit val format: OFormat[CbCRequestCommon] = Json.format[CbCRequestCommon]
+}
+
+case class CbCRequestDetail(
+  IDType: String = "CbC",
+  IDNumber: String = "YUDD789429"
+)
+
+object CbCRequestDetail {
+  implicit val format: OFormat[CbCRequestDetail] = Json.format[CbCRequestDetail]
+}
+
+/** Request payload originating from MTDP to display a Country by Country subscription
+  * */
+case class DisplaySubscriptionForCbCRequestPayload(
+  requestCommon: CbCRequestCommon,
+  requestDetail: CbCRequestDetail
+)
+
+object DisplaySubscriptionForCbCRequestPayload {
+  implicit val format: Format[DisplaySubscriptionForCbCRequestPayload] =
+    Json.format[DisplaySubscriptionForCbCRequestPayload]
+}
+
+// ************************************ //
+
+//   JSON sample response
+//  {
+//    "displaySubscriptionForCbCResponse": {
+//      "responseCommon": {
+//        "status": "OK",
+//        "processingDate": "2020-08-09T11:23:45Z"
+//      },
+//      "responseDetail": {
+//        "subscriptionID": "yu789428932",
+//        "tradingName": "Tools for Traders",
+//        "isGBUser": true,
+//        "primaryContact": [
+//          {
+//            "email": "Tim@toolsfortraders.com",
+//            "phone": "078803423883",
+//            "mobile": "078803423883",
+//            "individual": {
+//            "lastName": "Taylor",
+//            "firstName": "Tim"}
+//          }
+//        ],
+//        "secondaryContact": [
+//          {
+//            "email": "contact@toolsfortraders.com",
+//            "organisation": {"organisationName": "Tools for Traders Limited"}
+//          }
+//        ]
+//      }
+//    }
+//  }
+case class IndividualContact(
+  firstName: String,
+  lastName: String,
+  middleName: Option[String]
+)
+
+object IndividualContact {
+  implicit val format: OFormat[IndividualContact] = Json.format[IndividualContact]
+}
+
+case class OrganisationContact(organisationName: String)
+
+object OrganisationContact {
+  implicit val format: OFormat[OrganisationContact] = Json.format[OrganisationContact]
+}
+
+case class CbcContactInformation(
+  email: String,
+  phone: Option[String],
+  mobile: Option[String],
+  individual: Option[IndividualContact],
+  organisation: Option[OrganisationContact]
+)
+
+object CbcContactInformation {
+  implicit val format: OFormat[CbcContactInformation] = Json.format[CbcContactInformation]
+}
+
+case class CbCResponseCommon(
+  status: String,
+  processingDate: LocalDateTime
+)
+
+object CbCResponseCommon {
+  implicit val format: OFormat[CbCResponseCommon] = Json.format[CbCResponseCommon]
+}
+
+case class CbCResponseDetail(
+  cbcId: String,
+  tradingName: Option[String],
+  isGBUser: Boolean,
+  primaryContact: CbcContactInformation,
+  secondaryContact: CbcContactInformation
+)
+
+object CbCResponseDetail {
+  implicit val format: OFormat[CbCResponseDetail] = Json.format[CbCResponseDetail]
+}
+
+/** Response from EIS/ETMP for Country by Country subscription
+  */
+case class DisplaySubscriptionForCbC(
+  responseCommon: CbCResponseCommon,
+  responseDetails: CbCResponseDetail
+)
+
+object DisplaySubscriptionForCbC {
+  implicit val format: OFormat[DisplaySubscriptionForCbC] = Json.format[DisplaySubscriptionForCbC]
+}
+
+// TODO: Generate a DisplaySubscriptionForCbCRecord
+//
+// Seed
+//  cbcId: CbcId = "YUDD789429",
+//  requestParameters: Option[Map[String, String]]
+//
+// Outputs Uk or nonUK, with or without trading name - but contacts seem mandatory?
+
+//case class CbcSubscriptionDisplayRecord(
+//                                         id: Option[String] = None,
+//                                         cbcId: String,
+//                                         tradingName: Option[String],
+//                                         isGBUser: Boolean
+//                                       ) extends Record {
+//
+//  override def uniqueKey: Option[String] = Option(cbcId).map(CbcSubscriptionDisplayRecord.uniqueKey)
+//  override def lookupKeys: Seq[String] =
+//    Seq(Option(cbcId).map(CbcSubscriptionDisplayRecord.cbcIdKey)).collect { case Some(x) => x }
+//  override def withId(id: Option[String]): CbcSubscriptionDisplayRecord = copy(id = id)
+//
+//  def withCbcId(cbcId: String): CbcSubscriptionDisplayRecord = copy(cbcId = cbcId)
+//
+//}
+//
+//object CbcSubscriptionDisplayRecord extends RecordUtils[CbcSubscriptionDisplayRecord] {
+//  def uniqueKey(key: String): String = s"""cbcId:${key.toUpperCase}"""
+//  def CbcIdKey(key: String): String = s"""cbcId:${key.toUpperCase}"""
+//
+//  override val gen: Gen[CbcSubscriptionDisplayRecord] = _
+//  override val validate: Validator[CbcSubscriptionDisplayRecord] = _
+//  override val sanitizers: Seq[models.CbcSubscriptionDisplayRecord.Update] = _
+//}

--- a/app/uk/gov/hmrc/agentsexternalstubs/models/DisplaySubscriptionForCbC.scala
+++ b/app/uk/gov/hmrc/agentsexternalstubs/models/DisplaySubscriptionForCbC.scala
@@ -51,7 +51,7 @@ case class CbCRequestCommon(
   receiptDate: LocalDateTime,
   acknowledgementReference: String = "8493893huer3ruihuow",
   originatingSystem: String = "MDTP",
-  requestParameters: Option[Map[String, String]]
+  requestParameters: Option[Map[String, String]] = None // TODO fix error.expected.jsobject
 )
 
 object CbCRequestCommon {
@@ -60,22 +60,24 @@ object CbCRequestCommon {
 
 case class CbCRequestDetail(
   IDType: String = "CbC",
-  IDNumber: String = "YUDD789429"
+  IDNumber: String = "XACBC0123456789"
 )
 
 object CbCRequestDetail {
   implicit val format: OFormat[CbCRequestDetail] = Json.format[CbCRequestDetail]
 }
 
-/** Request payload originating from MTDP to display a Country by Country subscription
-  * */
-case class DisplaySubscriptionForCbCRequestPayload(
-  requestCommon: CbCRequestCommon,
-  requestDetail: CbCRequestDetail
-)
+case class DisplaySubscriptionForCbCRequest(requestCommon: CbCRequestCommon, requestDetail: CbCRequestDetail)
+
+object DisplaySubscriptionForCbCRequest {
+  implicit val format: OFormat[DisplaySubscriptionForCbCRequest] = Json.format[DisplaySubscriptionForCbCRequest]
+}
+
+/** Request payload originating from MTDP to display a Country by Country subscription */
+case class DisplaySubscriptionForCbCRequestPayload(displaySubscriptionForCbCRequest: DisplaySubscriptionForCbCRequest)
 
 object DisplaySubscriptionForCbCRequestPayload {
-  implicit val format: Format[DisplaySubscriptionForCbCRequestPayload] =
+  implicit val format: OFormat[DisplaySubscriptionForCbCRequestPayload] =
     Json.format[DisplaySubscriptionForCbCRequestPayload]
 }
 
@@ -160,12 +162,14 @@ object CbCResponseDetail {
   implicit val format: OFormat[CbCResponseDetail] = Json.format[CbCResponseDetail]
 }
 
-/** Response from EIS/ETMP for Country by Country subscription
-  */
-case class DisplaySubscriptionForCbC(
-  responseCommon: CbCResponseCommon,
-  responseDetails: CbCResponseDetail
-)
+case class DisplaySubscriptionForCbCResponse(responseCommon: CbCResponseCommon, responseDetails: CbCResponseDetail)
+
+object DisplaySubscriptionForCbCResponse {
+  implicit val format: OFormat[DisplaySubscriptionForCbCResponse] = Json.format[DisplaySubscriptionForCbCResponse]
+}
+
+/** Response from EIS/ETMP for Country by Country subscription */
+case class DisplaySubscriptionForCbC(displaySubscriptionForCbCResponse: DisplaySubscriptionForCbCResponse)
 
 object DisplaySubscriptionForCbC {
   implicit val format: OFormat[DisplaySubscriptionForCbC] = Json.format[DisplaySubscriptionForCbC]
@@ -175,7 +179,7 @@ object DisplaySubscriptionForCbC {
 //
 // Seed
 //  cbcId: CbcId = "YUDD789429",
-//  requestParameters: Option[Map[String, String]]
+//  ?? requestParameters: Option[Map[String, String]]
 //
 // Outputs Uk or nonUK, with or without trading name - but contacts seem mandatory?
 

--- a/app/uk/gov/hmrc/agentsexternalstubs/models/Identifier.scala
+++ b/app/uk/gov/hmrc/agentsexternalstubs/models/Identifier.scala
@@ -17,6 +17,7 @@
 package uk.gov.hmrc.agentsexternalstubs.models
 import play.api.libs.json.{Format, Json}
 
+// TODO delete this file? it is identical to the agent-mtd-identifiers version
 case class Identifier(key: String, value: String) {
   override def toString: String = s"$key~${value.replace(" ", "")}"
 }

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -55,7 +55,7 @@ DELETE        /tax-enrolments/users/:userId/enrolments/:enrolmentKey            
 ## ES19 Call: via tax-enrolments update friendly name
 PUT           /tax-enrolments/groups/:groupId/enrolments/:enrolmentKey/friendly_name                 @uk.gov.hmrc.agentsexternalstubs.controllers.EnrolmentStoreProxyStubController.setEnrolmentFriendlyName(groupId: String, enrolmentKey: EnrolmentKey)
 
-
+## DES/IF stubs
 GET           /registration/relationship/utr/:utr                                                    @uk.gov.hmrc.agentsexternalstubs.controllers.DesIfStubController.getLegacyRelationshipsByUtr(utr: String)
 GET           /registration/relationship/nino/:nino                                                  @uk.gov.hmrc.agentsexternalstubs.controllers.DesIfStubController.getLegacyRelationshipsByNino(nino: String)
 GET           /registration/business-details/:idType/:idNumber                                       @uk.gov.hmrc.agentsexternalstubs.controllers.DesIfStubController.getBusinessDetails(idType: String, idNumber: String)
@@ -114,6 +114,8 @@ POST          /agents-external-stubs/pdv-result/:id/:success                    
 GET           /companies-house-api-proxy/company/:companynumber                                      @uk.gov.hmrc.agentsexternalstubs.controllers.CompaniesHouseController.findCompany(companynumber: String)
 GET           /companies-house-api-proxy/company/:companynumber/officers                             @uk.gov.hmrc.agentsexternalstubs.controllers.CompaniesHouseController.findCompanyOfficers(companynumber: String, surname: Option[String])
 
+# Display Subscription For CbC - /dac/dct50d/v1 via Enterprise Integration System
+POST          /agents-external-stubs/cbc                                                              @uk.gov.hmrc.agentsexternalstubs.controllers.CountryByCountryController.displaySubscriptionForCbC
 
 # Authentication
 POST          /agents-external-stubs/sign-in                                                         @uk.gov.hmrc.agentsexternalstubs.controllers.SignInController.signIn

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -114,8 +114,8 @@ POST          /agents-external-stubs/pdv-result/:id/:success                    
 GET           /companies-house-api-proxy/company/:companynumber                                      @uk.gov.hmrc.agentsexternalstubs.controllers.CompaniesHouseController.findCompany(companynumber: String)
 GET           /companies-house-api-proxy/company/:companynumber/officers                             @uk.gov.hmrc.agentsexternalstubs.controllers.CompaniesHouseController.findCompanyOfficers(companynumber: String, surname: Option[String])
 
-# Display Subscription For CbC - /dac/dct50d/v1 via Enterprise Integration System
-POST          /agents-external-stubs/cbc                                                              @uk.gov.hmrc.agentsexternalstubs.controllers.CountryByCountryController.displaySubscriptionForCbC
+# Display Subscription For CbC - via Enterprise Integration System
+POST          /dac/dct50d/v1                                                                         @uk.gov.hmrc.agentsexternalstubs.controllers.CountryByCountryController.displaySubscriptionForCbC
 
 # Authentication
 POST          /agents-external-stubs/sign-in                                                         @uk.gov.hmrc.agentsexternalstubs.controllers.SignInController.signIn

--- a/conf/resources/country-by-country/full-response-template.json
+++ b/conf/resources/country-by-country/full-response-template.json
@@ -1,0 +1,31 @@
+{
+  "displaySubscriptionForCbCResponse": {
+    "responseCommon": {
+      "status": "OK",
+      "processingDate": "2020-08-09T11:23:45Z"
+    },  "responseDetail": {
+      "subscriptionID": "%%%COUNTRY_BY_COUNTRY_ID%%%",
+      "tradingName": "%%%TRADING_NAME%%%",
+      "isGBUser": true,
+      "primaryContact": [
+        {
+          "email": "Tim@toolsfortraders.com",
+          "phone": "078803423883",
+          "mobile": "078803423883",
+          "individual": {
+            "lastName": "Taylor",
+            "firstName": "Tim"
+          }
+        }
+      ],
+      "secondaryContact": [
+        {
+          "email": "contact@toolsfortraders.com",
+          "organisation": {
+            "organisationName": "Tools for Traders Limited"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/conf/resources/country-by-country/partial-response-template.json
+++ b/conf/resources/country-by-country/partial-response-template.json
@@ -1,0 +1,28 @@
+{
+  "displaySubscriptionForCbCResponse": {
+    "responseCommon": {
+      "status": "OK",
+      "processingDate": "2020-08-09T11:23:45Z"
+    },  "responseDetail": {
+      "subscriptionID": "%%%COUNTRY_BY_COUNTRY_ID%%%",
+      "isGBUser": false,
+      "primaryContact": [
+        {
+          "email": "Tim@toolsfortraders.com",
+          "individual": {
+            "lastName": "Taylor",
+            "firstName": "Tim"
+          }
+        }
+      ],
+      "secondaryContact": [
+        {
+          "email": "contact@toolsfortraders.com",
+          "organisation": {
+            "organisationName": "%%%TRADING_NAME%%%"
+          }
+        }
+      ]
+    }
+  }
+}

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -10,7 +10,7 @@ object AppDependencies {
     ws,
     "uk.gov.hmrc"          %% "bootstrap-backend-play-28" % bootstrapVer,
     "uk.gov.hmrc.mongo"    %% "hmrc-mongo-play-28"        % mongoVer,
-    "uk.gov.hmrc"          %% "agent-mtd-identifiers"     % "1.2.0",
+    "uk.gov.hmrc"          %% "agent-mtd-identifiers"     % "1.6.0",
     "com.kenshoo"          %% "metrics-play"              % "2.7.3_0.8.2",
     "com.github.blemale"   %% "scaffeine"                 % "4.0.1",
     "org.typelevel"        %% "cats-core"                 % "2.6.1",

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -10,7 +10,7 @@ object AppDependencies {
     ws,
     "uk.gov.hmrc"          %% "bootstrap-backend-play-28" % bootstrapVer,
     "uk.gov.hmrc.mongo"    %% "hmrc-mongo-play-28"        % mongoVer,
-    "uk.gov.hmrc"          %% "agent-mtd-identifiers"     % "1.6.0",
+    "uk.gov.hmrc"          %% "agent-mtd-identifiers"     % "1.9.0",
     "com.kenshoo"          %% "metrics-play"              % "2.7.3_0.8.2",
     "com.github.blemale"   %% "scaffeine"                 % "4.0.1",
     "org.typelevel"        %% "cats-core"                 % "2.6.1",

--- a/test/uk/gov/hmrc/agentsexternalstubs/RecordClassGeneratorFromJsonSchema.scala
+++ b/test/uk/gov/hmrc/agentsexternalstubs/RecordClassGeneratorFromJsonSchema.scala
@@ -23,7 +23,6 @@ import play.api.libs.json.{JsObject, Json}
 import uk.gov.hmrc.agentsexternalstubs.JsonSchema._
 import uk.gov.hmrc.agentsexternalstubs.RecordCodeRenderer.Context.safeName
 
-import scala.annotation.tailrec
 import scala.io.Source
 import scala.util.matching.Regex
 

--- a/test/uk/gov/hmrc/agentsexternalstubs/RecordClassGeneratorFromJsonSchema.scala
+++ b/test/uk/gov/hmrc/agentsexternalstubs/RecordClassGeneratorFromJsonSchema.scala
@@ -23,6 +23,7 @@ import play.api.libs.json.{JsObject, Json}
 import uk.gov.hmrc.agentsexternalstubs.JsonSchema._
 import uk.gov.hmrc.agentsexternalstubs.RecordCodeRenderer.Context.safeName
 
+import scala.annotation.tailrec
 import scala.io.Source
 import scala.util.matching.Regex
 
@@ -43,9 +44,9 @@ object RecordClassGeneratorFromJsonSchema extends App {
   val source = args(0)
   val sink = args(1)
   val className = args(2)
-  require(source != null && !source.isEmpty)
-  require(sink != null && !sink.isEmpty)
-  require(className != null && !className.isEmpty)
+  require(source != null && source.nonEmpty)
+  require(sink != null && sink.nonEmpty)
+  require(className != null && className.nonEmpty)
 
   val options = args.drop(3)
 
@@ -536,7 +537,7 @@ object RecordCodeRenderer extends JsonSchemaCodeRenderer with KnownFieldGenerato
           })
 
         case b: BooleanDefinition => "Generator.booleanGen"
-        case a: ArrayDefinition   => s"Generator.nonEmptyListOfMaxN(1,${generateValueGenerator(a.item, context, false)})"
+        case a: ArrayDefinition   => s"Generator.nonEmptyListOfMaxN(1,${generateValueGenerator(a.item, context, wrapOption = false)})"
         case o: ObjectDefinition  => s"${o.typeName}.gen"
 
         case o: OneOfDefinition =>


### PR DESCRIPTION
I've got a sample response coming back for a request with mandatory fields, the optional "requestParameters" result in JS error... I don't think we need this yet, but I will try and fix that.

POST /agents-external-stubs/cbc
Example request body:
```
{
    "displaySubscriptionForCbCRequest": {
        "requestCommon": {
            "regime": "CbC",
            "conversationID": "d3937a26-a4ec-4f11-bd8d-a93fc0265701",
            "receiptDate": "2020-09-15T09:38:00Z",
            "acknowledgementReference": "8493893huer3ruihuow",
            "originatingSystem": "MDTP"
        },
        "requestDetail": {
            "IDType": "CbC",
            "IDNumber": "XACBC0123456789"
        }
    }
}
```

It validates the CbC id based off off agent-mtd-identifiers. I've got some data generators for records in progress on another branch, but is this enough for what you need in `agent-invitations-frontend` @dg-21-hmrc ?