### PR TITLE
draft [CS] move 'core' stubs functionality to separate 'admin' dir

### DIFF
--- a/app/uk/gov/hmrc/agentsexternalstubs/controllers/AuthStubController.scala
+++ b/app/uk/gov/hmrc/agentsexternalstubs/controllers/AuthStubController.scala
@@ -24,6 +24,7 @@ import play.api.libs.json._
 import play.api.mvc._
 import uk.gov.hmrc.agentsexternalstubs.connectors.AgentAccessControlConnector
 import uk.gov.hmrc.agentsexternalstubs.models._
+import uk.gov.hmrc.agentsexternalstubs.models.admin.{AG, Group, User}
 import uk.gov.hmrc.agentsexternalstubs.services.{AuthenticationService, AuthorisationCache, GroupsService, UsersService}
 import uk.gov.hmrc.agentsexternalstubs.wiring.AppConfig
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController

--- a/app/uk/gov/hmrc/agentsexternalstubs/controllers/CitizenDetailsStubController.scala
+++ b/app/uk/gov/hmrc/agentsexternalstubs/controllers/CitizenDetailsStubController.scala
@@ -20,11 +20,12 @@ import javax.inject.{Inject, Singleton}
 import play.api.libs.json.{Format, Json, OFormat}
 import play.api.mvc.{Action, AnyContent, ControllerComponents}
 import uk.gov.hmrc.agentsexternalstubs.controllers.CitizenDetailsStubController.{GetCitizenResponse, GetDesignatoryDetailsBasicResponse, GetDesignatoryDetailsResponse}
-import uk.gov.hmrc.agentsexternalstubs.models.{AG, AuthenticatedSession, Group, User, UserGenerator}
+import uk.gov.hmrc.agentsexternalstubs.models.AuthenticatedSession
 import uk.gov.hmrc.agentsexternalstubs.services.{AuthenticationService, GroupsService, UsersService}
 import uk.gov.hmrc.domain.Nino
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 import uk.gov.hmrc.agentmtdidentifiers.model.Utr
+import uk.gov.hmrc.agentsexternalstubs.models.admin.{AG, Group, User, UserGenerator}
 
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter

--- a/app/uk/gov/hmrc/agentsexternalstubs/controllers/CurrentSession.scala
+++ b/app/uk/gov/hmrc/agentsexternalstubs/controllers/CurrentSession.scala
@@ -19,7 +19,8 @@ import play.api.Logger
 import play.api.libs.json.{JsValue, Json, Writes}
 import play.api.mvc.{Request, RequestHeader, Result, Results}
 import play.mvc.Http.HeaderNames
-import uk.gov.hmrc.agentsexternalstubs.models.{AuthenticatedSession, Planet, User}
+import uk.gov.hmrc.agentsexternalstubs.models.admin.{Planet, User}
+import uk.gov.hmrc.agentsexternalstubs.models.AuthenticatedSession
 import uk.gov.hmrc.agentsexternalstubs.services.{AuthenticationService, UsersService}
 import uk.gov.hmrc.auth.core.AuthorisationException
 import uk.gov.hmrc.http.{BadRequestException, HeaderCarrier, HttpException, NotFoundException}

--- a/app/uk/gov/hmrc/agentsexternalstubs/controllers/DesIfStubController.scala
+++ b/app/uk/gov/hmrc/agentsexternalstubs/controllers/DesIfStubController.scala
@@ -24,6 +24,7 @@ import play.api.mvc.{Action, AnyContent, ControllerComponents, Result}
 import uk.gov.hmrc.agentmtdidentifiers.model.{Arn, MtdItId, PptRef, Utr}
 import uk.gov.hmrc.agentsexternalstubs.models.TrustDetailsResponse.getErrorResponseFor
 import uk.gov.hmrc.agentsexternalstubs.models._
+import uk.gov.hmrc.agentsexternalstubs.models.admin.{AG, Group, User, UserGenerator}
 import uk.gov.hmrc.agentsexternalstubs.repository.RecordsRepository
 import uk.gov.hmrc.agentsexternalstubs.services._
 import uk.gov.hmrc.domain.Nino

--- a/app/uk/gov/hmrc/agentsexternalstubs/controllers/EnrolmentStoreProxyStubController.scala
+++ b/app/uk/gov/hmrc/agentsexternalstubs/controllers/EnrolmentStoreProxyStubController.scala
@@ -24,6 +24,7 @@ import uk.gov.hmrc.agentsexternalstubs.controllers.EnrolmentStoreProxyStubContro
 import uk.gov.hmrc.agentsexternalstubs.controllers.EnrolmentStoreProxyStubController._
 import uk.gov.hmrc.agentsexternalstubs.models.Validator.{Validator, check, checkProperty}
 import uk.gov.hmrc.agentsexternalstubs.models._
+import uk.gov.hmrc.agentsexternalstubs.models.admin.{Group, User}
 import uk.gov.hmrc.agentsexternalstubs.repository.{DuplicateUserException, KnownFactsRepository}
 import uk.gov.hmrc.agentsexternalstubs.services.{AuthenticationService, EnrolmentAlreadyExists, GroupsService, UsersService}
 import uk.gov.hmrc.auth.core.UnsupportedCredentialRole

--- a/app/uk/gov/hmrc/agentsexternalstubs/controllers/IdentityVerificationController.scala
+++ b/app/uk/gov/hmrc/agentsexternalstubs/controllers/IdentityVerificationController.scala
@@ -18,7 +18,8 @@ package uk.gov.hmrc.agentsexternalstubs.controllers
 
 import play.api.libs.json.JsValue
 import play.api.mvc.{Action, ControllerComponents}
-import uk.gov.hmrc.agentsexternalstubs.models.{NinoClStoreEntry, User}
+import uk.gov.hmrc.agentsexternalstubs.models.NinoClStoreEntry
+import uk.gov.hmrc.agentsexternalstubs.models.admin.User
 import uk.gov.hmrc.agentsexternalstubs.repository.DuplicateUserException
 import uk.gov.hmrc.agentsexternalstubs.services.{AuthenticationService, UsersService}
 import uk.gov.hmrc.domain.Nino

--- a/app/uk/gov/hmrc/agentsexternalstubs/controllers/SignInController.scala
+++ b/app/uk/gov/hmrc/agentsexternalstubs/controllers/SignInController.scala
@@ -21,7 +21,7 @@ import javax.inject.{Inject, Singleton}
 import play.api.http.HeaderNames
 import play.api.mvc.{Action, AnyContent, ControllerComponents, Result}
 import uk.gov.hmrc.agentsexternalstubs.models._
-import uk.gov.hmrc.agentsexternalstubs.services.{AuthenticationService, GroupsService, UsersService}
+import uk.gov.hmrc.agentsexternalstubs.services.{AuthenticationService, UsersService}
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 
 import scala.concurrent.{ExecutionContext, Future}
@@ -31,12 +31,12 @@ import uk.gov.hmrc.agentsexternalstubs.wiring.AppConfig
 
 import scala.util.Random
 import play.api.Logger
+import uk.gov.hmrc.agentsexternalstubs.models.admin.{AG, Group, User, UserIdGenerator}
 
 @Singleton
 class SignInController @Inject() (
   val authenticationService: AuthenticationService,
   usersService: UsersService,
-  groupsService: GroupsService,
   authLoginApiConnector: AuthLoginApiConnector,
   appConfig: AppConfig,
   cc: ControllerComponents

--- a/app/uk/gov/hmrc/agentsexternalstubs/controllers/admin/ConfigController.scala
+++ b/app/uk/gov/hmrc/agentsexternalstubs/controllers/admin/ConfigController.scala
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.agentsexternalstubs.controllers
+package uk.gov.hmrc.agentsexternalstubs.controllers.admin
 
 import play.api.mvc.{Action, AnyContent, ControllerComponents}
+import uk.gov.hmrc.agentsexternalstubs.controllers.{CurrentSession, RestfulResponse}
 import uk.gov.hmrc.agentsexternalstubs.models._
 import uk.gov.hmrc.agentsexternalstubs.services.AuthenticationService
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController

--- a/app/uk/gov/hmrc/agentsexternalstubs/controllers/admin/GroupsController.scala
+++ b/app/uk/gov/hmrc/agentsexternalstubs/controllers/admin/GroupsController.scala
@@ -14,12 +14,13 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.agentsexternalstubs.controllers
+package uk.gov.hmrc.agentsexternalstubs.controllers.admin
 
 import play.api.libs.json.JsValue
 import play.api.mvc.{Action, AnyContent, ControllerComponents}
 import play.mvc.Http.HeaderNames
-import uk.gov.hmrc.agentsexternalstubs.models.{Group, GroupGenerator, Groups}
+import uk.gov.hmrc.agentsexternalstubs.controllers.{CurrentSession, Link, RestfulResponse}
+import uk.gov.hmrc.agentsexternalstubs.models.admin.{Group, GroupGenerator, Groups}
 import uk.gov.hmrc.agentsexternalstubs.repository.DuplicateGroupException
 import uk.gov.hmrc.agentsexternalstubs.services.{AuthenticationService, GroupsService, UsersService}
 import uk.gov.hmrc.http.NotFoundException

--- a/app/uk/gov/hmrc/agentsexternalstubs/controllers/admin/KnownFactsController.scala
+++ b/app/uk/gov/hmrc/agentsexternalstubs/controllers/admin/KnownFactsController.scala
@@ -14,17 +14,19 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.agentsexternalstubs.controllers
+package uk.gov.hmrc.agentsexternalstubs.controllers.admin
 
-import javax.inject.{Inject, Singleton}
 import play.api.libs.json.{JsValue, Json, OWrites, Reads}
 import play.api.mvc.{Action, AnyContent, ControllerComponents}
 import play.mvc.Http.HeaderNames
-import uk.gov.hmrc.agentsexternalstubs.models.{EnrolmentKey, KnownFact, KnownFacts, User}
+import uk.gov.hmrc.agentsexternalstubs.controllers.CurrentSession
+import uk.gov.hmrc.agentsexternalstubs.models.admin.User
+import uk.gov.hmrc.agentsexternalstubs.models.{EnrolmentKey, KnownFact, KnownFacts}
 import uk.gov.hmrc.agentsexternalstubs.repository.{KnownFactsRepository, UsersRepository}
 import uk.gov.hmrc.agentsexternalstubs.services.AuthenticationService
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 
+import javax.inject.{Inject, Singleton}
 import scala.concurrent.ExecutionContext
 
 @Singleton

--- a/app/uk/gov/hmrc/agentsexternalstubs/controllers/admin/PlanetsController.scala
+++ b/app/uk/gov/hmrc/agentsexternalstubs/controllers/admin/PlanetsController.scala
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.agentsexternalstubs.controllers
+package uk.gov.hmrc.agentsexternalstubs.controllers.admin
 
 import play.api.Logger
 import play.api.mvc.{Action, AnyContent, ControllerComponents}
-import uk.gov.hmrc.agentsexternalstubs.models.UserIdGenerator
+import uk.gov.hmrc.agentsexternalstubs.models.admin.UserIdGenerator
 import uk.gov.hmrc.agentsexternalstubs.repository._
 import uk.gov.hmrc.agentsexternalstubs.services.AuthorisationCache
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController

--- a/app/uk/gov/hmrc/agentsexternalstubs/controllers/admin/SpecialCasesController.scala
+++ b/app/uk/gov/hmrc/agentsexternalstubs/controllers/admin/SpecialCasesController.scala
@@ -14,23 +14,24 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.agentsexternalstubs.controllers
+package uk.gov.hmrc.agentsexternalstubs.controllers.admin
 
-import java.net.URLDecoder
 import akka.stream.Materializer
 import akka.util.ByteString
-
-import javax.inject.{Inject, Singleton}
 import play.api.libs.json.{JsValue, Reads, Writes}
 import play.api.libs.streams.Accumulator
 import play.api.mvc._
 import play.mvc.Http.HeaderNames
-import uk.gov.hmrc.agentsexternalstubs.models.{AuthenticatedSession, Id, SpecialCase}
+import uk.gov.hmrc.agentsexternalstubs.controllers.{CurrentPlanetId, CurrentSession}
+import uk.gov.hmrc.agentsexternalstubs.models.admin.SpecialCase
+import uk.gov.hmrc.agentsexternalstubs.models.{AuthenticatedSession, Id}
 import uk.gov.hmrc.agentsexternalstubs.repository.SpecialCasesRepository
 import uk.gov.hmrc.agentsexternalstubs.services.AuthenticationService
 import uk.gov.hmrc.agentsexternalstubs.wiring.AppConfig
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 
+import java.net.URLDecoder
+import javax.inject.{Inject, Singleton}
 import scala.concurrent.ExecutionContext
 
 @Singleton

--- a/app/uk/gov/hmrc/agentsexternalstubs/controllers/admin/UserDetailsStubController.scala
+++ b/app/uk/gov/hmrc/agentsexternalstubs/controllers/admin/UserDetailsStubController.scala
@@ -14,16 +14,18 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.agentsexternalstubs.controllers
+package uk.gov.hmrc.agentsexternalstubs.controllers.admin
 
-import javax.inject.{Inject, Singleton}
 import play.api.libs.json.{Json, Writes}
 import play.api.mvc.{Action, AnyContent, ControllerComponents}
-import uk.gov.hmrc.agentsexternalstubs.models.{AG, AuthenticatedSession, Generator, Group, User}
+import uk.gov.hmrc.agentsexternalstubs.controllers.{CurrentSession, RestfulResponse}
+import uk.gov.hmrc.agentsexternalstubs.models._
+import uk.gov.hmrc.agentsexternalstubs.models.admin.{AG, Group, User}
 import uk.gov.hmrc.agentsexternalstubs.services.{AuthenticationService, UsersService}
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 
 import java.time.format.DateTimeFormatter
+import javax.inject.{Inject, Singleton}
 import scala.concurrent.ExecutionContext
 @Singleton
 class UserDetailsStubController @Inject() (

--- a/app/uk/gov/hmrc/agentsexternalstubs/controllers/admin/UsersController.scala
+++ b/app/uk/gov/hmrc/agentsexternalstubs/controllers/admin/UsersController.scala
@@ -14,18 +14,20 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.agentsexternalstubs.controllers
+package uk.gov.hmrc.agentsexternalstubs.controllers.admin
 
-import javax.inject.{Inject, Singleton}
 import play.api.libs.json.JsValue
 import play.api.mvc.{Action, AnyContent, ControllerComponents, Result}
 import play.mvc.Http.HeaderNames
-import uk.gov.hmrc.agentsexternalstubs.models.{ApiPlatform, User, UserIdGenerator, Users}
+import uk.gov.hmrc.agentsexternalstubs.controllers._
+import uk.gov.hmrc.agentsexternalstubs.models.ApiPlatform
+import uk.gov.hmrc.agentsexternalstubs.models.admin.{User, UserIdGenerator, Users}
 import uk.gov.hmrc.agentsexternalstubs.repository.DuplicateUserException
 import uk.gov.hmrc.agentsexternalstubs.services.{AuthenticationService, GroupsService, UsersService}
 import uk.gov.hmrc.http.NotFoundException
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 
+import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton

--- a/app/uk/gov/hmrc/agentsexternalstubs/controllers/admin/UsersGroupsSearchStubController.scala
+++ b/app/uk/gov/hmrc/agentsexternalstubs/controllers/admin/UsersGroupsSearchStubController.scala
@@ -14,16 +14,18 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.agentsexternalstubs.controllers
+package uk.gov.hmrc.agentsexternalstubs.controllers.admin
 
-import javax.inject.{Inject, Singleton}
 import play.api.libs.json.{JsArray, JsObject, Json, Writes}
 import play.api.mvc.{Action, AnyContent, ControllerComponents}
-import uk.gov.hmrc.agentsexternalstubs.controllers.UsersGroupsSearchStubController.{GetGroupResponse, GetUserResponse}
-import uk.gov.hmrc.agentsexternalstubs.models.{AG, Generator, Group, User}
+import uk.gov.hmrc.agentsexternalstubs.controllers.admin.UsersGroupsSearchStubController.{GetGroupResponse, GetUserResponse}
+import uk.gov.hmrc.agentsexternalstubs.controllers.{CurrentSession, Link, RestfulResponse}
+import uk.gov.hmrc.agentsexternalstubs.models.admin.{AG, Group, User}
+import uk.gov.hmrc.agentsexternalstubs.models.Generator
 import uk.gov.hmrc.agentsexternalstubs.services.{AuthenticationService, GroupsService, UsersService}
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController
 
+import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton

--- a/app/uk/gov/hmrc/agentsexternalstubs/controllers/datagen/AgencyCreator.scala
+++ b/app/uk/gov/hmrc/agentsexternalstubs/controllers/datagen/AgencyCreator.scala
@@ -23,6 +23,7 @@ import uk.gov.hmrc.agentsexternalstubs.models.BusinessDetailsRecord.BusinessData
 import uk.gov.hmrc.agentsexternalstubs.models.BusinessPartnerRecord.AgencyDetails
 import uk.gov.hmrc.agentsexternalstubs.models.VatCustomerInformationRecord.{ApprovedInformation, CustomerDetails, PPOB}
 import uk.gov.hmrc.agentsexternalstubs.models._
+import uk.gov.hmrc.agentsexternalstubs.models.admin.{AG, Group, User}
 import uk.gov.hmrc.agentsexternalstubs.repository._
 
 import java.time.LocalDate

--- a/app/uk/gov/hmrc/agentsexternalstubs/controllers/datagen/AgencyDataAssembler.scala
+++ b/app/uk/gov/hmrc/agentsexternalstubs/controllers/datagen/AgencyDataAssembler.scala
@@ -18,8 +18,9 @@ package uk.gov.hmrc.agentsexternalstubs.controllers.datagen
 
 import play.api.Logging
 import uk.gov.hmrc.agentsexternalstubs.models.PPTSubscriptionDisplayRecord.Common
-import uk.gov.hmrc.agentsexternalstubs.models.User.CR
+import uk.gov.hmrc.agentsexternalstubs.models.admin.User.CR
 import uk.gov.hmrc.agentsexternalstubs.models._
+import uk.gov.hmrc.agentsexternalstubs.models.admin.{AG, User, UserGenerator}
 
 import scala.annotation.tailrec
 import scala.util.Random

--- a/app/uk/gov/hmrc/agentsexternalstubs/controllers/datagen/GranPermsController.scala
+++ b/app/uk/gov/hmrc/agentsexternalstubs/controllers/datagen/GranPermsController.scala
@@ -19,7 +19,8 @@ package uk.gov.hmrc.agentsexternalstubs.controllers.datagen
 import play.api.libs.json.{JsValue, Json}
 import play.api.mvc.{Action, ControllerComponents}
 import uk.gov.hmrc.agentsexternalstubs.controllers.CurrentSession
-import uk.gov.hmrc.agentsexternalstubs.models.{AG, GranPermsGenRequest, GranPermsGenResponse, User}
+import uk.gov.hmrc.agentsexternalstubs.models.admin._
+import uk.gov.hmrc.agentsexternalstubs.models.{GranPermsGenRequest, GranPermsGenResponse}
 import uk.gov.hmrc.agentsexternalstubs.services.{AuthenticationService, GranPermsService, UsersService}
 import uk.gov.hmrc.agentsexternalstubs.wiring.AppConfig
 import uk.gov.hmrc.play.bootstrap.backend.controller.BackendController

--- a/app/uk/gov/hmrc/agentsexternalstubs/models/ApiPlatform.scala
+++ b/app/uk/gov/hmrc/agentsexternalstubs/models/ApiPlatform.scala
@@ -16,7 +16,8 @@
 
 package uk.gov.hmrc.agentsexternalstubs.models
 import play.api.libs.json.{Format, Json}
-import uk.gov.hmrc.agentsexternalstubs.models.User.AdditionalInformation
+import uk.gov.hmrc.agentsexternalstubs.models.admin.User.AdditionalInformation
+import uk.gov.hmrc.agentsexternalstubs.models.admin.{AG, Group, GroupGenerator, User}
 import uk.gov.hmrc.domain.{EmpRef, Nino}
 
 import java.time.LocalDate
@@ -87,7 +88,7 @@ object ApiPlatform {
 
     def asUserAndGroup(testUser: TestUser): (User, Group) = {
       val groupId = GroupGenerator.groupId(seed = testUser.hashCode().toString)
-      val user = User(
+      val user = admin.User(
         userId = testUser.userId,
         groupId = Some(groupId),
         confidenceLevel = if (testUser.affinityGroup == AG.Individual) Some(250) else None,

--- a/app/uk/gov/hmrc/agentsexternalstubs/models/AuthLoginApi.scala
+++ b/app/uk/gov/hmrc/agentsexternalstubs/models/AuthLoginApi.scala
@@ -16,6 +16,7 @@
 
 package uk.gov.hmrc.agentsexternalstubs.models
 import play.api.libs.json.{Format, Json, Reads}
+import uk.gov.hmrc.agentsexternalstubs.models.admin.{AG, Group, User}
 
 object AuthLoginApi {
 

--- a/app/uk/gov/hmrc/agentsexternalstubs/models/AuthoriseContext.scala
+++ b/app/uk/gov/hmrc/agentsexternalstubs/models/AuthoriseContext.scala
@@ -17,6 +17,7 @@
 package uk.gov.hmrc.agentsexternalstubs.models
 
 import uk.gov.hmrc.agentsexternalstubs.connectors.AgentAccessControlConnector
+import uk.gov.hmrc.agentsexternalstubs.models.admin.{AG, Group, User}
 import uk.gov.hmrc.domain.Nino
 import uk.gov.hmrc.http.HeaderCarrier
 

--- a/app/uk/gov/hmrc/agentsexternalstubs/models/AuthoriseResponse.scala
+++ b/app/uk/gov/hmrc/agentsexternalstubs/models/AuthoriseResponse.scala
@@ -17,6 +17,7 @@
 package uk.gov.hmrc.agentsexternalstubs.models
 
 import play.api.libs.json.{Format, Json}
+import uk.gov.hmrc.agentsexternalstubs.models.admin.AG
 import uk.gov.hmrc.domain.Nino
 
 import java.time.LocalDate

--- a/app/uk/gov/hmrc/agentsexternalstubs/models/BusinessPartnerRecord.scala
+++ b/app/uk/gov/hmrc/agentsexternalstubs/models/BusinessPartnerRecord.scala
@@ -21,6 +21,7 @@ import play.api.libs.json._
 import uk.gov.hmrc.agentmtdidentifiers.model.SuspensionDetails
 import uk.gov.hmrc.agentsexternalstubs.models.BusinessPartnerRecord._
 import uk.gov.hmrc.agentsexternalstubs.models.Validator.checkProperty
+import uk.gov.hmrc.agentsexternalstubs.models.admin.UserGenerator
 
 /** ----------------------------------------------------------------------------
   * THIS FILE HAS BEEN GENERATED - DO NOT MODIFY IT, CHANGE THE SCHEMA IF NEEDED

--- a/app/uk/gov/hmrc/agentsexternalstubs/models/KnownFacts.scala
+++ b/app/uk/gov/hmrc/agentsexternalstubs/models/KnownFacts.scala
@@ -18,6 +18,7 @@ package uk.gov.hmrc.agentsexternalstubs.models
 import cats.data.Validated
 import cats.data.Validated.{Invalid, Valid}
 import play.api.libs.json._
+import uk.gov.hmrc.agentsexternalstubs.models.admin.Planet
 
 case class KnownFacts(
   enrolmentKey: EnrolmentKey,

--- a/app/uk/gov/hmrc/agentsexternalstubs/models/LegacyAgentRecord.scala
+++ b/app/uk/gov/hmrc/agentsexternalstubs/models/LegacyAgentRecord.scala
@@ -18,6 +18,7 @@ package uk.gov.hmrc.agentsexternalstubs.models
 
 import org.scalacheck.Gen
 import play.api.libs.json.{Format, Json}
+import uk.gov.hmrc.agentsexternalstubs.models.admin.UserGenerator
 case class LegacyAgentRecord(
   agentId: String,
   agentOwnRef: Option[String] = None,

--- a/app/uk/gov/hmrc/agentsexternalstubs/models/PPTSubscriptionDisplayRecord.scala
+++ b/app/uk/gov/hmrc/agentsexternalstubs/models/PPTSubscriptionDisplayRecord.scala
@@ -21,6 +21,7 @@ import play.api.libs.json._
 import uk.gov.hmrc.agentsexternalstubs.models.PPTSubscriptionDisplayRecord.ChangeOfCircumstanceDetails.DeregistrationDetails
 import uk.gov.hmrc.agentsexternalstubs.models.PPTSubscriptionDisplayRecord.LegalEntityDetails.CustomerDetails
 import uk.gov.hmrc.agentsexternalstubs.models.PPTSubscriptionDisplayRecord._
+import uk.gov.hmrc.agentsexternalstubs.models.admin.AG
 import uk.gov.hmrc.smartstub.{Female, Male, Names}
 
 import java.text.SimpleDateFormat

--- a/app/uk/gov/hmrc/agentsexternalstubs/models/Services.scala
+++ b/app/uk/gov/hmrc/agentsexternalstubs/models/Services.scala
@@ -16,10 +16,10 @@
 
 package uk.gov.hmrc.agentsexternalstubs.models
 import java.util.Base64
-
 import org.scalacheck.{Arbitrary, Gen}
 import play.api.libs.json.{Format, Json}
 import uk.gov.hmrc.agentsexternalstubs.models.RegexPatterns.Matcher
+import uk.gov.hmrc.agentsexternalstubs.models.admin.AG
 
 import scala.io.Source
 import java.io._

--- a/app/uk/gov/hmrc/agentsexternalstubs/models/SignInRequest.scala
+++ b/app/uk/gov/hmrc/agentsexternalstubs/models/SignInRequest.scala
@@ -17,6 +17,7 @@
 package uk.gov.hmrc.agentsexternalstubs.models
 
 import play.api.libs.json.{Format, Json}
+import uk.gov.hmrc.agentsexternalstubs.models.admin.User
 
 case class SignInRequest(
   userId: Option[String],

--- a/app/uk/gov/hmrc/agentsexternalstubs/models/TrustDetails.scala
+++ b/app/uk/gov/hmrc/agentsexternalstubs/models/TrustDetails.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.agentsexternalstubs.models
 import play.api.libs.json.{Format, Json}
 import play.api.mvc.Result
 import uk.gov.hmrc.agentsexternalstubs.controllers.HttpHelpers
-import uk.gov.hmrc.agentsexternalstubs.models.User.Address
+import uk.gov.hmrc.agentsexternalstubs.models.admin.User.Address
 
 case class TrustAddress(
   line1: String,

--- a/app/uk/gov/hmrc/agentsexternalstubs/models/admin/Group.scala
+++ b/app/uk/gov/hmrc/agentsexternalstubs/models/admin/Group.scala
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.agentsexternalstubs.models
+package uk.gov.hmrc.agentsexternalstubs.models.admin
 
 import cats.data.Validated.{Invalid, Valid}
 import play.api.libs.json.{Json, OFormat}
+import uk.gov.hmrc.agentsexternalstubs.models.Enrolment
 
 case class Group(
   planetId: String,

--- a/app/uk/gov/hmrc/agentsexternalstubs/models/admin/GroupGenerator.scala
+++ b/app/uk/gov/hmrc/agentsexternalstubs/models/admin/GroupGenerator.scala
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.agentsexternalstubs.models
+package uk.gov.hmrc.agentsexternalstubs.models.admin
 
 import org.scalacheck.Gen
+import uk.gov.hmrc.agentsexternalstubs.models.Enrolment
 
 import java.util.UUID
 

--- a/app/uk/gov/hmrc/agentsexternalstubs/models/admin/GroupSanitizer.scala
+++ b/app/uk/gov/hmrc/agentsexternalstubs/models/admin/GroupSanitizer.scala
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.agentsexternalstubs.models
+package uk.gov.hmrc.agentsexternalstubs.models.admin
 
 import org.scalacheck.Gen
 import uk.gov.hmrc.agentsexternalstubs.models.Validator.Validator
+import uk.gov.hmrc.agentsexternalstubs.models._
 
 object GroupSanitizer extends RecordUtils[Group] {
 
@@ -47,8 +48,8 @@ object GroupSanitizer extends RecordUtils[Group] {
     group =>
       group.affinityGroup match {
         case AG.Agent =>
-          import uk.gov.hmrc.smartstub._
           import uk.gov.hmrc.agentsexternalstubs.models.Generator._
+          import uk.gov.hmrc.smartstub._
           if (group.agentId.isEmpty)
             group.copy(agentId = Some(LegacyRelationshipRecord.agentIdGen.seeded(group.groupId).get))
           else group

--- a/app/uk/gov/hmrc/agentsexternalstubs/models/admin/GroupUsersValidator.scala
+++ b/app/uk/gov/hmrc/agentsexternalstubs/models/admin/GroupUsersValidator.scala
@@ -14,9 +14,11 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.agentsexternalstubs.models
+package uk.gov.hmrc.agentsexternalstubs.models.admin
+
 import cats.data.Validated
 import cats.data.Validated.{Invalid, Valid}
+import uk.gov.hmrc.agentsexternalstubs.models.Validator
 
 object GroupUsersValidator {
 

--- a/app/uk/gov/hmrc/agentsexternalstubs/models/admin/GroupValidator.scala
+++ b/app/uk/gov/hmrc/agentsexternalstubs/models/admin/GroupValidator.scala
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.agentsexternalstubs.models
+package uk.gov.hmrc.agentsexternalstubs.models.admin
 
 import cats.data.Validated
 import cats.data.Validated.{Invalid, Valid}
+import uk.gov.hmrc.agentsexternalstubs.models.{Enrolment, Services, Validator}
 
 object GroupValidator {
 

--- a/app/uk/gov/hmrc/agentsexternalstubs/models/admin/Groups.scala
+++ b/app/uk/gov/hmrc/agentsexternalstubs/models/admin/Groups.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.agentsexternalstubs.models
+package uk.gov.hmrc.agentsexternalstubs.models.admin
 
 import play.api.libs.json.{Format, Json, Writes}
 

--- a/app/uk/gov/hmrc/agentsexternalstubs/models/admin/Planet.scala
+++ b/app/uk/gov/hmrc/agentsexternalstubs/models/admin/Planet.scala
@@ -14,12 +14,8 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.agentsexternalstubs.models
-import play.api.libs.json.{Format, Json, Writes}
+package uk.gov.hmrc.agentsexternalstubs.models.admin
 
-case class Users(users: Seq[User])
-
-object Users {
-  implicit val userWrites: Writes[User] = User.writes
-  implicit def format: Format[Users] = Json.format[Users]
+object Planet {
+  val DEFAULT: String = "hmrc"
 }

--- a/app/uk/gov/hmrc/agentsexternalstubs/models/admin/SpecialCase.scala
+++ b/app/uk/gov/hmrc/agentsexternalstubs/models/admin/SpecialCase.scala
@@ -14,14 +14,16 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.agentsexternalstubs.models
-import java.net.URLEncoder
+package uk.gov.hmrc.agentsexternalstubs.models.admin
 
 import akka.util.ByteString
 import play.api.http.HttpEntity
 import play.api.libs.json._
 import play.api.mvc.{ResponseHeader, Result}
 import play.mvc.Http.HeaderNames
+import uk.gov.hmrc.agentsexternalstubs.models.{Id, Validator}
+
+import java.net.URLEncoder
 
 case class SpecialCase(
   requestMatch: SpecialCase.RequestMatch,

--- a/app/uk/gov/hmrc/agentsexternalstubs/models/admin/User.scala
+++ b/app/uk/gov/hmrc/agentsexternalstubs/models/admin/User.scala
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.agentsexternalstubs.models
+package uk.gov.hmrc.agentsexternalstubs.models.admin
 
 import cats.data.Validated.{Invalid, Valid}
 import play.api.libs.json._
-import uk.gov.hmrc.agentsexternalstubs.models.User.AdditionalInformation
+import uk.gov.hmrc.agentsexternalstubs.models.admin.User.AdditionalInformation
+import uk.gov.hmrc.agentsexternalstubs.models.{Enrolment, EnrolmentKey, Generator, Identifier}
 import uk.gov.hmrc.domain.Nino
 
 import java.time.LocalDate

--- a/app/uk/gov/hmrc/agentsexternalstubs/models/admin/UserGenerator.scala
+++ b/app/uk/gov/hmrc/agentsexternalstubs/models/admin/UserGenerator.scala
@@ -14,13 +14,14 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.agentsexternalstubs.models
-import java.util.UUID
+package uk.gov.hmrc.agentsexternalstubs.models.admin
+
 import org.scalacheck.Gen
 import uk.gov.hmrc.domain.Nino
 
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
+import java.util.UUID
 
 object UserGenerator {
 
@@ -38,6 +39,7 @@ object UserGenerator {
   val nameForAgentGen: Gen[String] = for {
     f <- forename().suchThat(_.length > 0); s <- surname.suchThat(_.length > 0)
   } yield s"$f $s"
+
   def nameForAgent(userId: String, groupId: String): String =
     s"${forename().suchThat(_.length > 0).seeded(userId).getOrElse("Agent")} ${surname.suchThat(_.length > 0).seeded(groupId).getOrElse("Cooper")}"
 
@@ -55,12 +57,15 @@ object UserGenerator {
     date(dateOfBirthLow, dateOfBirthHigh).seeded(userId).map(d => LocalDate.parse(d.toString)).get
 
   private final val groupIdGen = pattern"9Z9Z-Z9Z9-9Z9Z-Z9Z9".gen
+
   def groupId(seed: String): String = groupIdGen.seeded(seed).get
 
   private final val agentCodeGen = pattern"ZZZZZZ999999".gen
+
   def agentCode(seed: String): String = agentCodeGen.seeded(seed).get
 
   private final val agentIdGen = pattern"999999".gen
+
   def agentId(seed: String): String = agentIdGen.seeded(seed).get
 
   def sex(userId: String): String = Gen.oneOf("M", "F").seeded(userId).get
@@ -79,6 +84,7 @@ object UserGenerator {
                 " & " + ln
               )
   } yield s"$ln$suffix"
+
   def agentFriendlyName(userId: String): String =
     agencyNameGen.seeded(userId + "_agent").get
 

--- a/app/uk/gov/hmrc/agentsexternalstubs/models/admin/UserIdGenerator.scala
+++ b/app/uk/gov/hmrc/agentsexternalstubs/models/admin/UserIdGenerator.scala
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.agentsexternalstubs.models
-import java.util.concurrent.ConcurrentHashMap
+package uk.gov.hmrc.agentsexternalstubs.models.admin
 
+import java.util.concurrent.ConcurrentHashMap
 import scala.io.Source
 import scala.util.Random
 
@@ -55,7 +55,9 @@ object UserIdGenerator {
 
   private class UserIdIterator(userIds: Seq[String]) extends Iterator[String] {
     @volatile var i = 0
+
     override def hasNext: Boolean = i < userIds.length - 1
+
     override def next(): String = {
       val id = userIds(i)
       i = i + 1

--- a/app/uk/gov/hmrc/agentsexternalstubs/models/admin/UserSanitizer.scala
+++ b/app/uk/gov/hmrc/agentsexternalstubs/models/admin/UserSanitizer.scala
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.agentsexternalstubs.models
+package uk.gov.hmrc.agentsexternalstubs.models.admin
 
 import org.scalacheck.Gen
 import uk.gov.hmrc.agentsexternalstubs.models.Validator.Validator
+import uk.gov.hmrc.agentsexternalstubs.models._
 
 case class UserSanitizer(affinityGroup: Option[String]) extends RecordUtils[User] {
 

--- a/app/uk/gov/hmrc/agentsexternalstubs/models/admin/UserValidator.scala
+++ b/app/uk/gov/hmrc/agentsexternalstubs/models/admin/UserValidator.scala
@@ -14,9 +14,11 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.agentsexternalstubs.models
+package uk.gov.hmrc.agentsexternalstubs.models.admin
+
 import cats.data.Validated
 import cats.data.Validated.{Invalid, Valid}
+import uk.gov.hmrc.agentsexternalstubs.models.{Enrolment, Services, Validator}
 
 case class UserValidator(affinityGroup: Option[String]) {
 

--- a/app/uk/gov/hmrc/agentsexternalstubs/models/admin/Users.scala
+++ b/app/uk/gov/hmrc/agentsexternalstubs/models/admin/Users.scala
@@ -14,8 +14,13 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.agentsexternalstubs.models
+package uk.gov.hmrc.agentsexternalstubs.models.admin
 
-object Planet {
-  val DEFAULT: String = "hmrc"
+import play.api.libs.json.{Format, Json, Writes}
+
+case class Users(users: Seq[User])
+
+object Users {
+  implicit val userWrites: Writes[User] = User.writes
+  implicit def format: Format[Users] = Json.format[Users]
 }

--- a/app/uk/gov/hmrc/agentsexternalstubs/repository/GroupsRepository.scala
+++ b/app/uk/gov/hmrc/agentsexternalstubs/repository/GroupsRepository.scala
@@ -22,7 +22,8 @@ import org.mongodb.scala.model._
 import org.mongodb.scala.result.DeleteResult
 import play.api.libs.json._
 import play.api.{Logger, Logging}
-import uk.gov.hmrc.agentsexternalstubs.models.{Enrolment, EnrolmentKey, Group}
+import uk.gov.hmrc.agentsexternalstubs.models.admin.Group
+import uk.gov.hmrc.agentsexternalstubs.models.{Enrolment, EnrolmentKey}
 import uk.gov.hmrc.agentsexternalstubs.repository.GroupsRepositoryMongo._
 import uk.gov.hmrc.agentsexternalstubs.syntax.|>
 import uk.gov.hmrc.mongo.MongoComponent

--- a/app/uk/gov/hmrc/agentsexternalstubs/repository/SpecialCasesRepository.scala
+++ b/app/uk/gov/hmrc/agentsexternalstubs/repository/SpecialCasesRepository.scala
@@ -19,8 +19,9 @@ package uk.gov.hmrc.agentsexternalstubs.repository
 import com.google.inject.ImplementedBy
 import org.mongodb.scala.model.{Filters, IndexModel, IndexOptions, Indexes, ReplaceOptions}
 import play.api.libs.json.{OWrites => _, _}
-import uk.gov.hmrc.agentsexternalstubs.models.SpecialCase.internal
-import uk.gov.hmrc.agentsexternalstubs.models.{Id, SpecialCase}
+import uk.gov.hmrc.agentsexternalstubs.models.admin.SpecialCase
+import uk.gov.hmrc.agentsexternalstubs.models.admin.SpecialCase.internal
+import uk.gov.hmrc.agentsexternalstubs.models.Id
 import uk.gov.hmrc.mongo.MongoComponent
 import uk.gov.hmrc.mongo.play.json.PlayMongoRepository
 import SpecialCasesRepositoryMongo._

--- a/app/uk/gov/hmrc/agentsexternalstubs/repository/UsersRepository.scala
+++ b/app/uk/gov/hmrc/agentsexternalstubs/repository/UsersRepository.scala
@@ -25,7 +25,8 @@ import org.mongodb.scala.model._
 import org.mongodb.scala.result.DeleteResult
 import play.api.libs.json._
 import play.api.{Logger, Logging}
-import uk.gov.hmrc.agentsexternalstubs.models.{EnrolmentKey, User}
+import uk.gov.hmrc.agentsexternalstubs.models.EnrolmentKey
+import uk.gov.hmrc.agentsexternalstubs.models.admin.User
 import uk.gov.hmrc.agentsexternalstubs.repository.UsersRepositoryMongo._
 import uk.gov.hmrc.mongo.MongoComponent
 import uk.gov.hmrc.mongo.play.json.PlayMongoRepository

--- a/app/uk/gov/hmrc/agentsexternalstubs/services/AuthenticationService.scala
+++ b/app/uk/gov/hmrc/agentsexternalstubs/services/AuthenticationService.scala
@@ -17,10 +17,10 @@
 package uk.gov.hmrc.agentsexternalstubs.services
 
 import java.util.UUID
-
 import javax.inject.{Inject, Singleton}
 import play.api.Logger
-import uk.gov.hmrc.agentsexternalstubs.models.{AuthenticateRequest, AuthenticatedSession, Planet}
+import uk.gov.hmrc.agentsexternalstubs.models.admin.Planet
+import uk.gov.hmrc.agentsexternalstubs.models.{AuthenticateRequest, AuthenticatedSession}
 import uk.gov.hmrc.agentsexternalstubs.repository.AuthenticatedSessionsRepository
 import uk.gov.hmrc.http.HeaderCarrier
 

--- a/app/uk/gov/hmrc/agentsexternalstubs/services/AuthorisationCache.scala
+++ b/app/uk/gov/hmrc/agentsexternalstubs/services/AuthorisationCache.scala
@@ -17,11 +17,11 @@
 package uk.gov.hmrc.agentsexternalstubs.services
 import java.util.concurrent.ConcurrentHashMap
 import java.util.function.BiFunction
-
 import com.github.blemale.scaffeine.{Cache, Scaffeine}
 import uk.gov.hmrc.agentsexternalstubs.controllers.AuthStubController.Authorise
 import uk.gov.hmrc.agentsexternalstubs.models.Retrieve.MaybeResponse
 import uk.gov.hmrc.agentsexternalstubs.models._
+import uk.gov.hmrc.agentsexternalstubs.models.admin.{Group, User}
 
 import scala.concurrent.ExecutionContext
 import scala.concurrent.duration._

--- a/app/uk/gov/hmrc/agentsexternalstubs/services/ExternalAuthorisationService.scala
+++ b/app/uk/gov/hmrc/agentsexternalstubs/services/ExternalAuthorisationService.scala
@@ -21,8 +21,10 @@ import play.api.Logger
 import play.api.libs.json.Json
 import uk.gov.hmrc.agentsexternalstubs.controllers.BearerToken
 import uk.gov.hmrc.agentsexternalstubs.models._
+import uk.gov.hmrc.agentsexternalstubs.models.admin.{Group, User}
 import uk.gov.hmrc.agentsexternalstubs.wiring.AppConfig
 import uk.gov.hmrc.http.{HeaderCarrier, HttpPost, Upstream4xxResponse, Upstream5xxResponse}
+
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.control.NonFatal
 

--- a/app/uk/gov/hmrc/agentsexternalstubs/services/ExternalUserService.scala
+++ b/app/uk/gov/hmrc/agentsexternalstubs/services/ExternalUserService.scala
@@ -21,7 +21,8 @@ import play.api.Logger
 import uk.gov.hmrc.agentmtdidentifiers.model.Utr
 import uk.gov.hmrc.agentsexternalstubs.connectors.ApiPlatformTestUserConnector
 import uk.gov.hmrc.agentsexternalstubs.models.ApiPlatform.TestUser
-import uk.gov.hmrc.agentsexternalstubs.models.{EnrolmentKey, Planet, User}
+import uk.gov.hmrc.agentsexternalstubs.models.admin.{Planet, User}
+import uk.gov.hmrc.agentsexternalstubs.models.EnrolmentKey
 import uk.gov.hmrc.agentsexternalstubs.wiring.AppConfig
 import uk.gov.hmrc.domain.{Nino, SaUtr, Vrn}
 import uk.gov.hmrc.http.HeaderCarrier

--- a/app/uk/gov/hmrc/agentsexternalstubs/services/GranPermsService.scala
+++ b/app/uk/gov/hmrc/agentsexternalstubs/services/GranPermsService.scala
@@ -18,6 +18,7 @@ package uk.gov.hmrc.agentsexternalstubs.services
 
 import cats.implicits._
 import uk.gov.hmrc.agentsexternalstubs.models._
+import uk.gov.hmrc.agentsexternalstubs.models.admin.{AG, Group, User, UserGenerator}
 import uk.gov.hmrc.domain.Nino
 
 import javax.inject.{Inject, Singleton}

--- a/app/uk/gov/hmrc/agentsexternalstubs/services/GroupsService.scala
+++ b/app/uk/gov/hmrc/agentsexternalstubs/services/GroupsService.scala
@@ -19,6 +19,7 @@ package uk.gov.hmrc.agentsexternalstubs.services
 import com.github.blemale.scaffeine.Scaffeine
 import play.api.i18n.Lang.logger
 import uk.gov.hmrc.agentsexternalstubs.models._
+import uk.gov.hmrc.agentsexternalstubs.models.admin.{AG, Group, GroupSanitizer, User, UserGenerator}
 import uk.gov.hmrc.agentsexternalstubs.repository.{GroupsRepository, KnownFactsRepository}
 import uk.gov.hmrc.auth.core.UnsupportedCredentialRole
 import uk.gov.hmrc.http.{BadRequestException, NotFoundException}

--- a/app/uk/gov/hmrc/agentsexternalstubs/services/LegacyRelationshipRecordsService.scala
+++ b/app/uk/gov/hmrc/agentsexternalstubs/services/LegacyRelationshipRecordsService.scala
@@ -16,8 +16,10 @@
 
 package uk.gov.hmrc.agentsexternalstubs.services
 
+import uk.gov.hmrc.agentsexternalstubs.models.admin.UserGenerator
+
 import javax.inject.{Inject, Singleton}
-import uk.gov.hmrc.agentsexternalstubs.models.{Generator, LegacyAgentRecord, LegacyRelationshipRecord, UserGenerator}
+import uk.gov.hmrc.agentsexternalstubs.models.{Generator, LegacyAgentRecord, LegacyRelationshipRecord}
 import uk.gov.hmrc.agentsexternalstubs.repository.RecordsRepository
 import uk.gov.hmrc.http.BadRequestException
 

--- a/app/uk/gov/hmrc/agentsexternalstubs/services/UserToRecordsSyncService.scala
+++ b/app/uk/gov/hmrc/agentsexternalstubs/services/UserToRecordsSyncService.scala
@@ -19,6 +19,7 @@ import uk.gov.hmrc.agentmtdidentifiers.model.{CgtRef, MtdItId, SuspensionDetails
 import uk.gov.hmrc.agentsexternalstubs.models.BusinessPartnerRecord.{AgencyDetails, Individual, Organisation}
 import uk.gov.hmrc.agentsexternalstubs.models.VatCustomerInformationRecord.{ApprovedInformation, CustomerDetails, IndividualName}
 import uk.gov.hmrc.agentsexternalstubs.models._
+import uk.gov.hmrc.agentsexternalstubs.models.admin.{AG, Group, User}
 import uk.gov.hmrc.agentsexternalstubs.repository.{KnownFactsRepository, UsersRepository}
 import uk.gov.hmrc.domain.Nino
 

--- a/app/uk/gov/hmrc/agentsexternalstubs/services/UsersService.scala
+++ b/app/uk/gov/hmrc/agentsexternalstubs/services/UsersService.scala
@@ -20,6 +20,7 @@ import cats.data.Validated.{Invalid, Valid}
 import com.github.blemale.scaffeine.Scaffeine
 import play.api.i18n.Lang.logger
 import uk.gov.hmrc.agentsexternalstubs.models._
+import uk.gov.hmrc.agentsexternalstubs.models.admin.{AG, Group, GroupGenerator, GroupUsersValidator, User, UserSanitizer}
 import uk.gov.hmrc.agentsexternalstubs.repository.{KnownFactsRepository, UsersRepository}
 import uk.gov.hmrc.domain.Nino
 import uk.gov.hmrc.http.{BadRequestException, ForbiddenException, NotFoundException}

--- a/app/uk/gov/hmrc/agentsexternalstubs/wiring/PreloadData.scala
+++ b/app/uk/gov/hmrc/agentsexternalstubs/wiring/PreloadData.scala
@@ -17,7 +17,8 @@
 package uk.gov.hmrc.agentsexternalstubs.wiring
 
 import play.api.Logger
-import uk.gov.hmrc.agentsexternalstubs.models.{BusinessDetailsRecord, BusinessPartnerRecord, UserIdGenerator, VatCustomerInformationRecord}
+import uk.gov.hmrc.agentsexternalstubs.models.admin.UserIdGenerator
+import uk.gov.hmrc.agentsexternalstubs.models.{BusinessDetailsRecord, BusinessPartnerRecord, VatCustomerInformationRecord}
 
 import javax.inject.{Inject, Singleton}
 

--- a/app/uk/gov/hmrc/agentsexternalstubs/wiring/SpecialCasesRequestHandler.scala
+++ b/app/uk/gov/hmrc/agentsexternalstubs/wiring/SpecialCasesRequestHandler.scala
@@ -23,7 +23,7 @@ import play.api.http.{HttpConfiguration, HttpErrorHandler, HttpFilters}
 import play.api.mvc._
 import play.api.routing.Router
 import play.core.WebCommands
-import uk.gov.hmrc.agentsexternalstubs.controllers.SpecialCasesController
+import uk.gov.hmrc.agentsexternalstubs.controllers.admin.SpecialCasesController
 
 class SpecialCasesRequestHandler @Inject() (
   webCommands: WebCommands,

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -13,7 +13,7 @@ GET           /auth/oid/:oid                                                    
 GET           /auth/oid/:oid/enrolments                                                              @uk.gov.hmrc.agentsexternalstubs.controllers.AuthStubController.getEnrolmentsByOid(oid:String)
 
 # User details stubs
-GET           /user-details/id/:id                                                                   @uk.gov.hmrc.agentsexternalstubs.controllers.UserDetailsStubController.getUser(id: String)
+GET           /user-details/id/:id                                                                   @uk.gov.hmrc.agentsexternalstubs.controllers.admin.UserDetailsStubController.getUser(id: String)
 
 # Citizen details stubs
 GET           /citizen-details/:nino/designatory-details/basic                                       @uk.gov.hmrc.agentsexternalstubs.controllers.CitizenDetailsStubController.getDesignatoryDetailsBasic(nino: String)
@@ -21,10 +21,10 @@ GET           /citizen-details/:nino/designatory-details                        
 GET           /citizen-details/:idName/:taxId                                                        @uk.gov.hmrc.agentsexternalstubs.controllers.CitizenDetailsStubController.getCitizen(idName: String, taxId: String)
 
 # Users Groups Search stubs
-GET           /users-groups-search/users/:userId                                                     @uk.gov.hmrc.agentsexternalstubs.controllers.UsersGroupsSearchStubController.getUser(userId: String)
-GET           /users-groups-search/groups/:groupId                                                   @uk.gov.hmrc.agentsexternalstubs.controllers.UsersGroupsSearchStubController.getGroup(groupId: String)
-GET           /users-groups-search/groups/:groupId/users                                             @uk.gov.hmrc.agentsexternalstubs.controllers.UsersGroupsSearchStubController.getGroupUsers(groupId: String)
-GET           /users-groups-search/groups                                                            @uk.gov.hmrc.agentsexternalstubs.controllers.UsersGroupsSearchStubController.getGroupByAgentCode(agentCode: String)
+GET           /users-groups-search/users/:userId                                                     @uk.gov.hmrc.agentsexternalstubs.controllers.admin.UsersGroupsSearchStubController.getUser(userId: String)
+GET           /users-groups-search/groups/:groupId                                                   @uk.gov.hmrc.agentsexternalstubs.controllers.admin.UsersGroupsSearchStubController.getGroup(groupId: String)
+GET           /users-groups-search/groups/:groupId/users                                             @uk.gov.hmrc.agentsexternalstubs.controllers.admin.UsersGroupsSearchStubController.getGroupUsers(groupId: String)
+GET           /users-groups-search/groups                                                            @uk.gov.hmrc.agentsexternalstubs.controllers.admin.UsersGroupsSearchStubController.getGroupByAgentCode(agentCode: String)
 
 # Enrolment Store Proxy stubs
 GET           /enrolment-store-proxy/enrolment-store/enrolments/:enrolmentKey/users                         @uk.gov.hmrc.agentsexternalstubs.controllers.EnrolmentStoreProxyStubController.getUserIds(enrolmentKey: EnrolmentKey, `type`: String ?= "all")
@@ -126,23 +126,23 @@ GET           /agents-external-stubs/session                                    
 GET           /agents-external-stubs/sign-out                                                        @uk.gov.hmrc.agentsexternalstubs.controllers.SignInController.signOut
 
 # User management
-GET           /agents-external-stubs/users                                                           @uk.gov.hmrc.agentsexternalstubs.controllers.UsersController.getUsers(affinityGroup: Option[String] ?= None, limit: Option[Int] ?= None, groupId: Option[String] ?= None, agentCode: Option[String] ?= None)
-GET           /agents-external-stubs/users/:userId                                                   @uk.gov.hmrc.agentsexternalstubs.controllers.UsersController.getUser(userId: String)
-PUT           /agents-external-stubs/users                                                           @uk.gov.hmrc.agentsexternalstubs.controllers.UsersController.updateCurrentUser
-PUT           /agents-external-stubs/users/:userId                                                   @uk.gov.hmrc.agentsexternalstubs.controllers.UsersController.updateUser(userId: String)
-POST          /agents-external-stubs/users                                                           @uk.gov.hmrc.agentsexternalstubs.controllers.UsersController.createUser(affinityGroup: Option[String], planetId: Option[String] ?= None)
-POST          /agents-external-stubs/users/api-platform                                              @uk.gov.hmrc.agentsexternalstubs.controllers.UsersController.createApiPlatformTestUser
-DELETE        /agents-external-stubs/users/:userId                                                   @uk.gov.hmrc.agentsexternalstubs.controllers.UsersController.deleteUser(userId: String)
-POST          /agents-external-stubs/users/re-index                                                  @uk.gov.hmrc.agentsexternalstubs.controllers.UsersController.reindexAllUsers()
+GET           /agents-external-stubs/users                                                           @uk.gov.hmrc.agentsexternalstubs.controllers.admin.UsersController.getUsers(affinityGroup: Option[String] ?= None, limit: Option[Int] ?= None, groupId: Option[String] ?= None, agentCode: Option[String] ?= None)
+GET           /agents-external-stubs/users/:userId                                                   @uk.gov.hmrc.agentsexternalstubs.controllers.admin.UsersController.getUser(userId: String)
+PUT           /agents-external-stubs/users                                                           @uk.gov.hmrc.agentsexternalstubs.controllers.admin.UsersController.updateCurrentUser
+PUT           /agents-external-stubs/users/:userId                                                   @uk.gov.hmrc.agentsexternalstubs.controllers.admin.UsersController.updateUser(userId: String)
+POST          /agents-external-stubs/users                                                           @uk.gov.hmrc.agentsexternalstubs.controllers.admin.UsersController.createUser(affinityGroup: Option[String], planetId: Option[String] ?= None)
+POST          /agents-external-stubs/users/api-platform                                              @uk.gov.hmrc.agentsexternalstubs.controllers.admin.UsersController.createApiPlatformTestUser
+DELETE        /agents-external-stubs/users/:userId                                                   @uk.gov.hmrc.agentsexternalstubs.controllers.admin.UsersController.deleteUser(userId: String)
+POST          /agents-external-stubs/users/re-index                                                  @uk.gov.hmrc.agentsexternalstubs.controllers.admin.UsersController.reindexAllUsers()
 
 # Group management
-GET           /agents-external-stubs/groups                                                          @uk.gov.hmrc.agentsexternalstubs.controllers.GroupsController.getGroups(affinityGroup: Option[String] ?= None, limit: Option[Int] ?= None, agentCode: Option[String] ?= None)
-GET           /agents-external-stubs/groups/:groupId                                                 @uk.gov.hmrc.agentsexternalstubs.controllers.GroupsController.getGroup(groupId: String)
-PUT           /agents-external-stubs/groups                                                          @uk.gov.hmrc.agentsexternalstubs.controllers.GroupsController.updateCurrentGroup
-PUT           /agents-external-stubs/groups/:groupId                                                 @uk.gov.hmrc.agentsexternalstubs.controllers.GroupsController.updateGroup(groupId: String)
-POST          /agents-external-stubs/groups                                                          @uk.gov.hmrc.agentsexternalstubs.controllers.GroupsController.createGroup
-DELETE        /agents-external-stubs/groups/:groupId                                                 @uk.gov.hmrc.agentsexternalstubs.controllers.GroupsController.deleteGroup(groupId: String)
-POST          /agents-external-stubs/groups/re-index                                                 @uk.gov.hmrc.agentsexternalstubs.controllers.GroupsController.reindexAllGroups()
+GET           /agents-external-stubs/groups                                                          @uk.gov.hmrc.agentsexternalstubs.controllers.admin.GroupsController.getGroups(affinityGroup: Option[String] ?= None, limit: Option[Int] ?= None, agentCode: Option[String] ?= None)
+GET           /agents-external-stubs/groups/:groupId                                                 @uk.gov.hmrc.agentsexternalstubs.controllers.admin.GroupsController.getGroup(groupId: String)
+PUT           /agents-external-stubs/groups                                                          @uk.gov.hmrc.agentsexternalstubs.controllers.admin.GroupsController.updateCurrentGroup
+PUT           /agents-external-stubs/groups/:groupId                                                 @uk.gov.hmrc.agentsexternalstubs.controllers.admin.GroupsController.updateGroup(groupId: String)
+POST          /agents-external-stubs/groups                                                          @uk.gov.hmrc.agentsexternalstubs.controllers.admin.GroupsController.createGroup
+DELETE        /agents-external-stubs/groups/:groupId                                                 @uk.gov.hmrc.agentsexternalstubs.controllers.admin.GroupsController.deleteGroup(groupId: String)
+POST          /agents-external-stubs/groups/re-index                                                 @uk.gov.hmrc.agentsexternalstubs.controllers.admin.GroupsController.reindexAllGroups()
 
 # Records management
 GET           /agents-external-stubs/records                                                         @uk.gov.hmrc.agentsexternalstubs.controllers.RecordsController.getRecords
@@ -170,19 +170,19 @@ POST          /agents-external-stubs/records/cbc-subscription                   
 GET           /agents-external-stubs/records/cbc-subscription/generate                               @uk.gov.hmrc.agentsexternalstubs.controllers.RecordsController.generateCbcSubscriptionRecord(seed: Option[String] ?= None, ninimal: Boolean ?= false)
 
 # Known facts management
-POST          /agents-external-stubs/known-facts                                                     @uk.gov.hmrc.agentsexternalstubs.controllers.KnownFactsController.createKnownFacts
-GET           /agents-external-stubs/known-facts/:enrolmentKey                                       @uk.gov.hmrc.agentsexternalstubs.controllers.KnownFactsController.getKnownFacts(enrolmentKey: EnrolmentKey)
-PUT           /agents-external-stubs/known-facts/:enrolmentKey                                       @uk.gov.hmrc.agentsexternalstubs.controllers.KnownFactsController.upsertKnownFacts(enrolmentKey: EnrolmentKey)
-PUT           /agents-external-stubs/known-facts/:enrolmentKey/verifier                              @uk.gov.hmrc.agentsexternalstubs.controllers.KnownFactsController.upsertKnownFactVerifier(enrolmentKey: EnrolmentKey)
-DELETE        /agents-external-stubs/known-facts/:enrolmentKey                                       @uk.gov.hmrc.agentsexternalstubs.controllers.KnownFactsController.deleteKnownFacts(enrolmentKey: EnrolmentKey)
-POST          /agents-external-stubs/known-facts/regime/PAYE/:agentId                                @uk.gov.hmrc.agentsexternalstubs.controllers.KnownFactsController.createPAYEKnownFacts(agentId: String)
+POST          /agents-external-stubs/known-facts                                                     @uk.gov.hmrc.agentsexternalstubs.controllers.admin.KnownFactsController.createKnownFacts
+GET           /agents-external-stubs/known-facts/:enrolmentKey                                       @uk.gov.hmrc.agentsexternalstubs.controllers.admin.KnownFactsController.getKnownFacts(enrolmentKey: EnrolmentKey)
+PUT           /agents-external-stubs/known-facts/:enrolmentKey                                       @uk.gov.hmrc.agentsexternalstubs.controllers.admin.KnownFactsController.upsertKnownFacts(enrolmentKey: EnrolmentKey)
+PUT           /agents-external-stubs/known-facts/:enrolmentKey/verifier                              @uk.gov.hmrc.agentsexternalstubs.controllers.admin.KnownFactsController.upsertKnownFactVerifier(enrolmentKey: EnrolmentKey)
+DELETE        /agents-external-stubs/known-facts/:enrolmentKey                                       @uk.gov.hmrc.agentsexternalstubs.controllers.admin.KnownFactsController.deleteKnownFacts(enrolmentKey: EnrolmentKey)
+POST          /agents-external-stubs/known-facts/regime/PAYE/:agentId                                @uk.gov.hmrc.agentsexternalstubs.controllers.admin.KnownFactsController.createPAYEKnownFacts(agentId: String)
 
 # Special cases management
-GET           /agents-external-stubs/special-cases                                                   @uk.gov.hmrc.agentsexternalstubs.controllers.SpecialCasesController.getAllSpecialCases
-POST          /agents-external-stubs/special-cases                                                   @uk.gov.hmrc.agentsexternalstubs.controllers.SpecialCasesController.createSpecialCase
-GET           /agents-external-stubs/special-cases/:id                                               @uk.gov.hmrc.agentsexternalstubs.controllers.SpecialCasesController.getSpecialCase(id: String)
-PUT           /agents-external-stubs/special-cases/:id                                               @uk.gov.hmrc.agentsexternalstubs.controllers.SpecialCasesController.updateSpecialCase(id: String)
-DELETE        /agents-external-stubs/special-cases/:id                                               @uk.gov.hmrc.agentsexternalstubs.controllers.SpecialCasesController.deleteSpecialCase(id: String)
+GET           /agents-external-stubs/special-cases                                                   @uk.gov.hmrc.agentsexternalstubs.controllers.admin.SpecialCasesController.getAllSpecialCases
+POST          /agents-external-stubs/special-cases                                                   @uk.gov.hmrc.agentsexternalstubs.controllers.admin.SpecialCasesController.createSpecialCase
+GET           /agents-external-stubs/special-cases/:id                                               @uk.gov.hmrc.agentsexternalstubs.controllers.admin.SpecialCasesController.getSpecialCase(id: String)
+PUT           /agents-external-stubs/special-cases/:id                                               @uk.gov.hmrc.agentsexternalstubs.controllers.admin.SpecialCasesController.updateSpecialCase(id: String)
+DELETE        /agents-external-stubs/special-cases/:id                                               @uk.gov.hmrc.agentsexternalstubs.controllers.admin.SpecialCasesController.deleteSpecialCase(id: String)
 
 #File Upload urls
 POST          /file-upload/envelopes                                                                 @uk.gov.hmrc.agentsexternalstubs.controllers.FileUploadController.createEnvelope()
@@ -194,10 +194,10 @@ POST          /agents-external-stubs/test/gran-perms/generate-users             
 POST          /agents-external-stubs/test/gran-perms/generate-perf-data                              @uk.gov.hmrc.agentsexternalstubs.controllers.datagen.PerfDataController.generate
 
 # Config management
-GET           /agents-external-stubs/config/services                                                 @uk.gov.hmrc.agentsexternalstubs.controllers.ConfigController.getServices
+GET           /agents-external-stubs/config/services                                                 @uk.gov.hmrc.agentsexternalstubs.controllers.admin.ConfigController.getServices
 
 # Planets management
-DELETE        /agents-external-stubs/planets/:planetId                                               @uk.gov.hmrc.agentsexternalstubs.controllers.PlanetsController.destroy(planetId: String)
+DELETE        /agents-external-stubs/planets/:planetId                                               @uk.gov.hmrc.agentsexternalstubs.controllers.admin.PlanetsController.destroy(planetId: String)
 
 # Generic proxy
 GET           /*path                                                                                 @uk.gov.hmrc.agentsexternalstubs.controllers.ProxyController.proxyPassTo(path: String)

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -50,7 +50,7 @@ controllers {
     needsLogging = false
   }
 
-  uk.gov.hmrc.agentsexternalstubs.controllers.ConfigController {
+  uk.gov.hmrc.agentsexternalstubs.controllers.admin.ConfigController {
     needsAuditing = false
     needsLogging = false
   }
@@ -70,12 +70,12 @@ controllers {
     needsLogging = false
   }
 
-  uk.gov.hmrc.agentsexternalstubs.controllers.KnownFactsController {
+  uk.gov.hmrc.agentsexternalstubs.controllers.admin.KnownFactsController {
     needsAuditing = false
     needsLogging = false
   }
 
-  uk.gov.hmrc.agentsexternalstubs.controllers.PlanetsController {
+  uk.gov.hmrc.agentsexternalstubs.controllers.admin.PlanetsController {
     needsAuditing = false
     needsLogging = false
   }
@@ -90,22 +90,22 @@ controllers {
     needsLogging = false
   }
 
-  uk.gov.hmrc.agentsexternalstubs.controllers.SpecialCasesController {
+  uk.gov.hmrc.agentsexternalstubs.controllers.admin.SpecialCasesController {
     needsAuditing = false
     needsLogging = false
   }
 
-  uk.gov.hmrc.agentsexternalstubs.controllers.UserDetailsStubController {
+  uk.gov.hmrc.agentsexternalstubs.controllers.admin.UserDetailsStubController {
     needsAuditing = false
     needsLogging = false
   }
 
-  uk.gov.hmrc.agentsexternalstubs.controllers.UsersController {
+  uk.gov.hmrc.agentsexternalstubs.controllers.admin.UsersController {
     needsAuditing = false
     needsLogging = false
   }
 
-  uk.gov.hmrc.agentsexternalstubs.controllers.UsersGroupsSearchStubController {
+  uk.gov.hmrc.agentsexternalstubs.controllers.admin.UsersGroupsSearchStubController {
     needsAuditing = false
     needsLogging = false
   }

--- a/it/uk/gov/hmrc/agentsexternalstubs/connectors/CitizenDetailsConnectorISpec.scala
+++ b/it/uk/gov/hmrc/agentsexternalstubs/connectors/CitizenDetailsConnectorISpec.scala
@@ -2,7 +2,8 @@ package uk.gov.hmrc.agentsexternalstubs.connectors
 
 import play.api.libs.ws.WSClient
 import play.api.test.Helpers._
-import uk.gov.hmrc.agentsexternalstubs.models.{AG, AuthenticatedSession, UserGenerator}
+import uk.gov.hmrc.agentsexternalstubs.models.admin.{AG, UserGenerator}
+import uk.gov.hmrc.agentsexternalstubs.models.AuthenticatedSession
 import uk.gov.hmrc.agentsexternalstubs.stubs.TestStubs
 import uk.gov.hmrc.agentsexternalstubs.support.{ServerBaseISpec, TestRequests}
 import uk.gov.hmrc.domain.Nino

--- a/it/uk/gov/hmrc/agentsexternalstubs/connectors/EnrolmentStoreProxyConnectorISpec.scala
+++ b/it/uk/gov/hmrc/agentsexternalstubs/connectors/EnrolmentStoreProxyConnectorISpec.scala
@@ -7,6 +7,7 @@ import play.api.libs.ws.WSClient
 import play.api.test.Helpers._
 import uk.gov.hmrc.agentmtdidentifiers.model.{Arn, MtdItId, Vrn}
 import uk.gov.hmrc.agentsexternalstubs.models._
+import uk.gov.hmrc.agentsexternalstubs.models.admin.{AG, Group, UserGenerator}
 import uk.gov.hmrc.agentsexternalstubs.stubs.TestStubs
 import uk.gov.hmrc.agentsexternalstubs.support._
 import uk.gov.hmrc.domain.{AgentCode, TaxIdentifier}

--- a/it/uk/gov/hmrc/agentsexternalstubs/connectors/UsersGroupsSearchConnectorISpec.scala
+++ b/it/uk/gov/hmrc/agentsexternalstubs/connectors/UsersGroupsSearchConnectorISpec.scala
@@ -2,7 +2,8 @@ package uk.gov.hmrc.agentsexternalstubs.connectors
 
 import play.api.libs.ws.WSClient
 import play.api.test.Helpers._
-import uk.gov.hmrc.agentsexternalstubs.models.{AG, AuthenticatedSession, Group, User, UserGenerator}
+import uk.gov.hmrc.agentsexternalstubs.models.admin.{AG, Group, User, UserGenerator}
+import uk.gov.hmrc.agentsexternalstubs.models.AuthenticatedSession
 import uk.gov.hmrc.agentsexternalstubs.stubs.TestStubs
 import uk.gov.hmrc.agentsexternalstubs.support.{ServerBaseISpec, TestRequests}
 

--- a/it/uk/gov/hmrc/agentsexternalstubs/controllers/AuthStubControllerISpec.scala
+++ b/it/uk/gov/hmrc/agentsexternalstubs/controllers/AuthStubControllerISpec.scala
@@ -6,8 +6,9 @@ import play.api.libs.json.JsObject
 import play.api.libs.ws.WSClient
 import play.api.test.Helpers._
 import uk.gov.hmrc.agentsexternalstubs.connectors.MicroserviceAuthConnector
-import uk.gov.hmrc.agentsexternalstubs.models.User.CR
-import uk.gov.hmrc.agentsexternalstubs.models.{AG, AuthenticatedSession, EnrolmentKey, User, UserGenerator}
+import uk.gov.hmrc.agentsexternalstubs.models.admin.User.CR
+import uk.gov.hmrc.agentsexternalstubs.models.admin.{AG, User, UserGenerator}
+import uk.gov.hmrc.agentsexternalstubs.models.{AuthenticatedSession, EnrolmentKey}
 import uk.gov.hmrc.agentsexternalstubs.stubs.TestStubs
 import uk.gov.hmrc.agentsexternalstubs.support._
 import uk.gov.hmrc.auth.core.AuthProvider.GovernmentGateway
@@ -157,7 +158,11 @@ class AuthStubControllerISpec extends ServerBaseISpec with TestRequests with Tes
 
       "authorise if user authenticated with the OneTimeLogin provider" in {
         val authToken: String =
-          givenAnAuthenticatedUser(User(randomId), providerType = "OneTimeLogin", affinityGroup = Some(AG.Individual))
+          givenAnAuthenticatedUser(
+            User(randomId),
+            providerType = "OneTimeLogin",
+            affinityGroup = Some(AG.Individual)
+          )
         await(
           authConnector
             .authorise[Unit](AuthProviders(AuthProvider.OneTimeLogin), EmptyRetrieval)(
@@ -242,7 +247,8 @@ class AuthStubControllerISpec extends ServerBaseISpec with TestRequests with Tes
 
       "throw InsufficientEnrolments if user not enrolled with expected identifier key" in {
         val id = randomId
-        val authToken: String = givenAnAuthenticatedUser(User(id), planetId = id, affinityGroup = Some(AG.Individual))
+        val authToken: String =
+          givenAnAuthenticatedUser(User(id), planetId = id, affinityGroup = Some(AG.Individual))
         givenUserEnrolledFor(
           id,
           planetId = id,
@@ -263,7 +269,8 @@ class AuthStubControllerISpec extends ServerBaseISpec with TestRequests with Tes
 
       "throw InsufficientEnrolments if user not enrolled with expected identifier value" in {
         val id = randomId
-        val authToken: String = givenAnAuthenticatedUser(User(id), planetId = id, affinityGroup = Some(AG.Individual))
+        val authToken: String =
+          givenAnAuthenticatedUser(User(id), planetId = id, affinityGroup = Some(AG.Individual))
         givenUserEnrolledFor(id, planetId = id, "HMRC-MTD-IT", "MTDITID", "236216873678126")
         an[InsufficientEnrolments] shouldBe thrownBy {
           await(
@@ -278,7 +285,8 @@ class AuthStubControllerISpec extends ServerBaseISpec with TestRequests with Tes
 
       "throw InsufficientEnrolments if user does not have NINO" in {
         val id = randomId
-        val authToken: String = givenAnAuthenticatedUser(User(id), planetId = id, affinityGroup = Some(AG.Individual))
+        val authToken: String =
+          givenAnAuthenticatedUser(User(id), planetId = id, affinityGroup = Some(AG.Individual))
         an[InsufficientEnrolments] shouldBe thrownBy {
           await(
             authConnector
@@ -318,7 +326,8 @@ class AuthStubControllerISpec extends ServerBaseISpec with TestRequests with Tes
 
       "retrieve authorisedEnrolments" in {
         val id = randomId
-        val authToken: String = givenAnAuthenticatedUser(User(id), planetId = id, affinityGroup = Some(AG.Individual))
+        val authToken: String =
+          givenAnAuthenticatedUser(User(id), planetId = id, affinityGroup = Some(AG.Individual))
         givenUserEnrolledFor(id, planetId = id, "HMRC-MTD-IT", "MTDITID", "236216873678126")
         givenUserEnrolledFor(id, planetId = id, "IR-SA", "UTR", "1234567890")
 
@@ -442,7 +451,8 @@ class AuthStubControllerISpec extends ServerBaseISpec with TestRequests with Tes
 
       "retrieve allEnrolments" in {
         val id = randomId
-        val authToken: String = givenAnAuthenticatedUser(User(id), planetId = id, affinityGroup = Some(AG.Individual))
+        val authToken: String =
+          givenAnAuthenticatedUser(User(id), planetId = id, affinityGroup = Some(AG.Individual))
         givenUserEnrolledFor(id, planetId = id, "HMRC-MTD-IT", "MTDITID", "236216873678126")
         givenUserEnrolledFor(id, planetId = id, "IR-SA", "UTR", "1234567890")
 
@@ -814,7 +824,10 @@ class AuthStubControllerISpec extends ServerBaseISpec with TestRequests with Tes
 
       "retrieve groupIdentifier" in {
         val authToken: String =
-          givenAnAuthenticatedUser(User(randomId, groupId = Some("AAA-999-XXX")), affinityGroup = Some(AG.Individual))
+          givenAnAuthenticatedUser(
+            User(randomId, groupId = Some("AAA-999-XXX")),
+            affinityGroup = Some(AG.Individual)
+          )
 
         val groupIdentifierOpt = await(
           authConnector

--- a/it/uk/gov/hmrc/agentsexternalstubs/controllers/CitizenDetailsStubControllerISpec.scala
+++ b/it/uk/gov/hmrc/agentsexternalstubs/controllers/CitizenDetailsStubControllerISpec.scala
@@ -2,7 +2,8 @@ package uk.gov.hmrc.agentsexternalstubs.controllers
 
 import play.api.libs.json.JsObject
 import play.api.libs.ws.WSClient
-import uk.gov.hmrc.agentsexternalstubs.models.{AG, AuthenticatedSession, UserGenerator}
+import uk.gov.hmrc.agentsexternalstubs.models.admin.{AG, UserGenerator}
+import uk.gov.hmrc.agentsexternalstubs.models.AuthenticatedSession
 import uk.gov.hmrc.agentsexternalstubs.stubs.TestStubs
 import uk.gov.hmrc.agentsexternalstubs.support.{NotAuthorized, ServerBaseISpec, TestRequests}
 

--- a/it/uk/gov/hmrc/agentsexternalstubs/controllers/DesIfStubControllerISpec.scala
+++ b/it/uk/gov/hmrc/agentsexternalstubs/controllers/DesIfStubControllerISpec.scala
@@ -10,6 +10,7 @@ import uk.gov.hmrc.agentsexternalstubs.controllers.ErrorResponse._
 import uk.gov.hmrc.agentsexternalstubs.models.BusinessPartnerRecord.Individual
 import uk.gov.hmrc.agentsexternalstubs.models.VatCustomerInformationRecord.{ApprovedInformation, CustomerDetails}
 import uk.gov.hmrc.agentsexternalstubs.models._
+import uk.gov.hmrc.agentsexternalstubs.models.admin.{AG, Group, Planet, User, UserGenerator}
 import uk.gov.hmrc.agentsexternalstubs.repository.RecordsRepository
 import uk.gov.hmrc.agentsexternalstubs.services.VatCustomerInformationRecordsService
 import uk.gov.hmrc.agentsexternalstubs.stubs.TestStubs

--- a/it/uk/gov/hmrc/agentsexternalstubs/controllers/EnrolmentStoreProxyStubControllerISpec.scala
+++ b/it/uk/gov/hmrc/agentsexternalstubs/controllers/EnrolmentStoreProxyStubControllerISpec.scala
@@ -1,12 +1,13 @@
 package uk.gov.hmrc.agentsexternalstubs.controllers
 
-import play.api.libs.json.{JsArray, JsObject, JsString, Json}
+import play.api.libs.json.{JsObject, Json}
 import play.api.libs.ws.WSClient
 import play.api.test.Helpers._
 import uk.gov.hmrc.agentmtdidentifiers.model.AssignedClient
 import uk.gov.hmrc.agentmtdidentifiers.model.{Identifier => _}
-import uk.gov.hmrc.agentsexternalstubs.controllers.EnrolmentStoreProxyStubController.{EnrolmentsFromKnownFactsRequest, IdentifiersAndVerifiers, SetKnownFactsRequest}
+import uk.gov.hmrc.agentsexternalstubs.controllers.EnrolmentStoreProxyStubController.{EnrolmentsFromKnownFactsRequest, SetKnownFactsRequest}
 import uk.gov.hmrc.agentsexternalstubs.models._
+import uk.gov.hmrc.agentsexternalstubs.models.admin.{AG, Group, GroupGenerator, User, UserGenerator}
 import uk.gov.hmrc.agentsexternalstubs.stubs.TestStubs
 import uk.gov.hmrc.agentsexternalstubs.support.{AuthContext, ServerBaseISpec, TestRequests}
 

--- a/it/uk/gov/hmrc/agentsexternalstubs/controllers/GranPermsControllerISpec.scala
+++ b/it/uk/gov/hmrc/agentsexternalstubs/controllers/GranPermsControllerISpec.scala
@@ -2,6 +2,7 @@ package uk.gov.hmrc.agentsexternalstubs.controllers
 
 import play.api.libs.ws.WSClient
 import uk.gov.hmrc.agentsexternalstubs.models._
+import uk.gov.hmrc.agentsexternalstubs.models.admin.{AG, Group, UserGenerator}
 import uk.gov.hmrc.agentsexternalstubs.services.{GroupsService, UsersService}
 import uk.gov.hmrc.agentsexternalstubs.support.{ServerBaseISpec, TestRequests}
 

--- a/it/uk/gov/hmrc/agentsexternalstubs/controllers/GroupsControllerISpec.scala
+++ b/it/uk/gov/hmrc/agentsexternalstubs/controllers/GroupsControllerISpec.scala
@@ -5,6 +5,7 @@ import play.api.http.Status
 import play.api.libs.ws.WSClient
 import play.mvc.Http.HeaderNames
 import uk.gov.hmrc.agentsexternalstubs.models._
+import uk.gov.hmrc.agentsexternalstubs.models.admin.{AG, Group, GroupGenerator, Groups, User, UserGenerator}
 import uk.gov.hmrc.agentsexternalstubs.services.GroupsService
 import uk.gov.hmrc.agentsexternalstubs.stubs.TestStubs
 import uk.gov.hmrc.agentsexternalstubs.support._

--- a/it/uk/gov/hmrc/agentsexternalstubs/controllers/PlanetsControllerISpec.scala
+++ b/it/uk/gov/hmrc/agentsexternalstubs/controllers/PlanetsControllerISpec.scala
@@ -3,8 +3,9 @@ package uk.gov.hmrc.agentsexternalstubs.controllers
 import play.api.libs.json.Json
 import play.api.libs.ws.WSClient
 import play.api.test.Helpers._
-import uk.gov.hmrc.agentsexternalstubs.controllers.SpecialCasesController.writes
-import uk.gov.hmrc.agentsexternalstubs.models.{AG, AuthenticatedSession, EnrolmentKey, Identifier, SpecialCase, UserGenerator}
+import uk.gov.hmrc.agentsexternalstubs.controllers.admin.SpecialCasesController.writes
+import uk.gov.hmrc.agentsexternalstubs.models.admin.{AG, SpecialCase, UserGenerator}
+import uk.gov.hmrc.agentsexternalstubs.models.{AuthenticatedSession, EnrolmentKey, Identifier}
 import uk.gov.hmrc.agentsexternalstubs.repository.{AuthenticatedSessionsRepository, GroupsRepository, KnownFactsRepository, RecordsRepository, SpecialCasesRepository, UsersRepository}
 import uk.gov.hmrc.agentsexternalstubs.support._
 

--- a/it/uk/gov/hmrc/agentsexternalstubs/controllers/SpecialCasesControllerISpec.scala
+++ b/it/uk/gov/hmrc/agentsexternalstubs/controllers/SpecialCasesControllerISpec.scala
@@ -4,7 +4,8 @@ import play.api.libs.json.{JsObject, Json, Reads, Writes}
 import play.api.libs.ws.WSClient
 import play.api.test.Helpers._
 import play.mvc.Http.{HeaderNames, MimeTypes}
-import uk.gov.hmrc.agentsexternalstubs.models.SpecialCase.RequestMatch
+import uk.gov.hmrc.agentsexternalstubs.models.admin.SpecialCase.RequestMatch
+import uk.gov.hmrc.agentsexternalstubs.models.admin._
 import uk.gov.hmrc.agentsexternalstubs.models._
 import uk.gov.hmrc.agentsexternalstubs.repository.SpecialCasesRepository
 import uk.gov.hmrc.agentsexternalstubs.support._

--- a/it/uk/gov/hmrc/agentsexternalstubs/controllers/UserDetailsStubControllerISpec.scala
+++ b/it/uk/gov/hmrc/agentsexternalstubs/controllers/UserDetailsStubControllerISpec.scala
@@ -2,6 +2,7 @@ package uk.gov.hmrc.agentsexternalstubs.controllers
 
 import play.api.libs.ws.WSClient
 import uk.gov.hmrc.agentsexternalstubs.models._
+import uk.gov.hmrc.agentsexternalstubs.models.admin.{AG, Group, User, UserGenerator}
 import uk.gov.hmrc.agentsexternalstubs.stubs.TestStubs
 import uk.gov.hmrc.agentsexternalstubs.support.{NotAuthorized, ServerBaseISpec, TestRequests}
 

--- a/it/uk/gov/hmrc/agentsexternalstubs/controllers/UsersControllerISpec.scala
+++ b/it/uk/gov/hmrc/agentsexternalstubs/controllers/UsersControllerISpec.scala
@@ -5,6 +5,7 @@ import play.api.libs.json.Json
 import play.api.libs.ws.WSClient
 import play.mvc.Http.HeaderNames
 import uk.gov.hmrc.agentsexternalstubs.models._
+import uk.gov.hmrc.agentsexternalstubs.models.admin.{AG, Group, Planet, User, UserGenerator, Users}
 import uk.gov.hmrc.agentsexternalstubs.services.UsersService
 import uk.gov.hmrc.agentsexternalstubs.stubs.TestStubs
 import uk.gov.hmrc.agentsexternalstubs.support._
@@ -140,7 +141,8 @@ class UsersControllerISpec extends ServerBaseISpec with TestRequests with TestSt
       "create a new user on a specified planet even if the caller is unauthenticated" in {
         val result = wsClient
           .url(s"$url/agents-external-stubs/users?affinityGroup=Individual&planetId=bar")
-          .withHttpHeaders(Seq.empty: _*) // no headers: unauthenticated
+          // no headers: unauthenticated
+          .withHttpHeaders(Seq.empty: _*)
           .post(Json.toJson(User("foo")))
           .futureValue
         result should haveStatus(201)
@@ -150,7 +152,8 @@ class UsersControllerISpec extends ServerBaseISpec with TestRequests with TestSt
       "not create a user if the caller is unauthenticated and planetId is not specified" in {
         val result = wsClient
           .url(s"$url/agents-external-stubs/users?affinityGroup=Individual")
-          .withHttpHeaders(Seq.empty: _*) // no headers: unauthenticated
+          // no headers: unauthenticated
+          .withHttpHeaders(Seq.empty: _*)
           .post(Json.toJson(User("foo")))
           .futureValue
         result should haveStatus(400)

--- a/it/uk/gov/hmrc/agentsexternalstubs/controllers/UsersGroupsSearchStubControllerISpec.scala
+++ b/it/uk/gov/hmrc/agentsexternalstubs/controllers/UsersGroupsSearchStubControllerISpec.scala
@@ -1,7 +1,8 @@
 package uk.gov.hmrc.agentsexternalstubs.controllers
 
 import play.api.libs.ws.WSClient
-import uk.gov.hmrc.agentsexternalstubs.models.{AG, AuthenticatedSession, User, UserGenerator}
+import uk.gov.hmrc.agentsexternalstubs.models.admin.{AG, User, UserGenerator}
+import uk.gov.hmrc.agentsexternalstubs.models.AuthenticatedSession
 import uk.gov.hmrc.agentsexternalstubs.stubs.TestStubs
 import uk.gov.hmrc.agentsexternalstubs.support.{ServerBaseISpec, TestRequests}
 

--- a/it/uk/gov/hmrc/agentsexternalstubs/repository/GroupsRepositoryISpec.scala
+++ b/it/uk/gov/hmrc/agentsexternalstubs/repository/GroupsRepositoryISpec.scala
@@ -17,6 +17,7 @@ package uk.gov.hmrc.agentsexternalstubs.repository
 
 import play.api.test.Helpers._
 import uk.gov.hmrc.agentsexternalstubs.models._
+import uk.gov.hmrc.agentsexternalstubs.models.admin.{AG, Group}
 import uk.gov.hmrc.agentsexternalstubs.support.AppBaseISpec
 
 import java.util.UUID

--- a/it/uk/gov/hmrc/agentsexternalstubs/repository/SpecialCasesRepositoryISpec.scala
+++ b/it/uk/gov/hmrc/agentsexternalstubs/repository/SpecialCasesRepositoryISpec.scala
@@ -16,8 +16,8 @@
 package uk.gov.hmrc.agentsexternalstubs.repository
 
 import java.util.UUID
-
-import uk.gov.hmrc.agentsexternalstubs.models.SpecialCase.RequestMatch
+import uk.gov.hmrc.agentsexternalstubs.models.admin.SpecialCase
+import uk.gov.hmrc.agentsexternalstubs.models.admin.SpecialCase.RequestMatch
 import uk.gov.hmrc.agentsexternalstubs.models._
 import uk.gov.hmrc.agentsexternalstubs.support.AppBaseISpec
 import play.api.test.Helpers._

--- a/it/uk/gov/hmrc/agentsexternalstubs/repository/UsersRepositoryISpec.scala
+++ b/it/uk/gov/hmrc/agentsexternalstubs/repository/UsersRepositoryISpec.scala
@@ -16,8 +16,7 @@
 package uk.gov.hmrc.agentsexternalstubs.repository
 
 import java.util.UUID
-
-import uk.gov.hmrc.agentsexternalstubs.models._
+import uk.gov.hmrc.agentsexternalstubs.models.admin.{User, UserGenerator}
 import uk.gov.hmrc.agentsexternalstubs.support.AppBaseISpec
 import uk.gov.hmrc.domain.Nino
 import play.api.test.Helpers._

--- a/it/uk/gov/hmrc/agentsexternalstubs/services/ExternalAuthorisationServiceISpec.scala
+++ b/it/uk/gov/hmrc/agentsexternalstubs/services/ExternalAuthorisationServiceISpec.scala
@@ -10,6 +10,7 @@ import uk.gov.hmrc.domain.Nino
 import uk.gov.hmrc.http.{Authorization, SessionId}
 import uk.gov.hmrc.http.{HeaderCarrier, HttpPost}
 import play.api.test.Helpers._
+import uk.gov.hmrc.agentsexternalstubs.models.admin.{AG, UserGenerator}
 
 import java.time.LocalDate
 import scala.concurrent.ExecutionContext

--- a/it/uk/gov/hmrc/agentsexternalstubs/services/UserToRecordsSyncServiceISpec.scala
+++ b/it/uk/gov/hmrc/agentsexternalstubs/services/UserToRecordsSyncServiceISpec.scala
@@ -10,6 +10,7 @@ import uk.gov.hmrc.agentsexternalstubs.repository.KnownFactsRepository
 import uk.gov.hmrc.agentsexternalstubs.support._
 import uk.gov.hmrc.domain.Nino
 import play.api.test.Helpers._
+import uk.gov.hmrc.agentsexternalstubs.models.admin.{AG, GroupGenerator, UserGenerator}
 
 import scala.concurrent.duration._
 

--- a/it/uk/gov/hmrc/agentsexternalstubs/stubs/TestStubs.scala
+++ b/it/uk/gov/hmrc/agentsexternalstubs/stubs/TestStubs.scala
@@ -4,6 +4,7 @@ import org.scalatest.Suite
 import play.api.Application
 import play.api.test.Helpers._
 import uk.gov.hmrc.agentsexternalstubs.models._
+import uk.gov.hmrc.agentsexternalstubs.models.admin.{AG, User, UserGenerator}
 import uk.gov.hmrc.agentsexternalstubs.services.{AuthenticationService, GroupsService, UsersService}
 
 import java.util.UUID

--- a/it/uk/gov/hmrc/agentsexternalstubs/support/ServerBaseISpec.scala
+++ b/it/uk/gov/hmrc/agentsexternalstubs/support/ServerBaseISpec.scala
@@ -29,7 +29,7 @@ abstract class ServerBaseISpec
 
   val url = s"http://localhost:$port"
 
-  import scala.concurrent.duration._
+  //import scala.concurrent.duration._
   //implicit val defaultTimeout: FiniteDuration = 30.seconds
 
   implicit val ec: ExecutionContext = scala.concurrent.ExecutionContext.global

--- a/it/uk/gov/hmrc/agentsexternalstubs/support/TestRequests.scala
+++ b/it/uk/gov/hmrc/agentsexternalstubs/support/TestRequests.scala
@@ -7,6 +7,7 @@ import play.api.libs.ws.{BodyWritable, WSClient, WSCookie, WSResponse}
 import play.api.mvc.{Cookie, DefaultCookieHeaderEncoding}
 import uk.gov.hmrc.agentsexternalstubs.controllers.EnrolmentStoreProxyStubController.EnrolmentsFromKnownFactsRequest
 import uk.gov.hmrc.agentsexternalstubs.models._
+import uk.gov.hmrc.agentsexternalstubs.models.admin.{AG, Group, GroupGenerator, User}
 import uk.gov.hmrc.http.{Authorization, HeaderCarrier}
 
 import java.util.UUID

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -3,7 +3,7 @@ import sbt._
 
 object AppDependencies {
 
-  private val bootstrapVer = "7.21.0"
+  private val bootstrapVer = "7.22.0"
   private val mongoVer = "1.3.0"
   
   lazy val compile = Seq(

--- a/test/uk/gov/hmrc/agentsexternalstubs/EnrolmentStoreProxyStubControllerSpec.scala
+++ b/test/uk/gov/hmrc/agentsexternalstubs/EnrolmentStoreProxyStubControllerSpec.scala
@@ -24,7 +24,8 @@ import play.api.libs.json.{JsValue, Json}
 import play.api.mvc.{ControllerComponents, Request, Result}
 import play.api.test.{FakeRequest, Helpers}
 import uk.gov.hmrc.agentsexternalstubs.controllers.EnrolmentStoreProxyStubController
-import uk.gov.hmrc.agentsexternalstubs.models.{AuthenticatedSession, EnrolmentKey, User}
+import uk.gov.hmrc.agentsexternalstubs.models.admin.User
+import uk.gov.hmrc.agentsexternalstubs.models.{AuthenticatedSession, EnrolmentKey}
 import uk.gov.hmrc.agentsexternalstubs.repository.{DuplicateUserException, KnownFactsRepository}
 import uk.gov.hmrc.agentsexternalstubs.services.{AuthenticationService, GroupsService, UsersService}
 import uk.gov.hmrc.http.HeaderCarrier

--- a/test/uk/gov/hmrc/agentsexternalstubs/controllers/CountryByCountryControllerSpec.scala
+++ b/test/uk/gov/hmrc/agentsexternalstubs/controllers/CountryByCountryControllerSpec.scala
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2023 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package uk.gov.hmrc.agentsexternalstubs.controllers
+
+import org.scalamock.handlers.CallHandler3
+import org.scalamock.scalatest.MockFactory
+import play.api.libs.json.{JsValue, Json}
+import play.api.mvc.{AnyContentAsEmpty, ControllerComponents, Result}
+import play.api.test.{FakeHeaders, FakeRequest, Helpers}
+import uk.gov.hmrc.agentmtdidentifiers.model.CbcId
+import uk.gov.hmrc.agentsexternalstubs.models.Generator.cbcId
+import uk.gov.hmrc.agentsexternalstubs.models._
+import uk.gov.hmrc.agentsexternalstubs.services.{AuthenticationService, CbCSubscriptionRecordsService}
+import uk.gov.hmrc.agentsexternalstubs.support.BaseUnitSpec
+import uk.gov.hmrc.http.{BadRequestException, HeaderCarrier, SessionKeys}
+
+import java.time.LocalDateTime
+import java.util.UUID
+import scala.concurrent.{ExecutionContext, Future}
+
+class CountryByCountryControllerSpec extends BaseUnitSpec with MockFactory {
+
+  trait TestScope {
+    val mockAuthService: AuthenticationService = mock[AuthenticationService]
+    val mockCbcService: CbCSubscriptionRecordsService = mock[CbCSubscriptionRecordsService]
+    val controllerComponents: ControllerComponents = Helpers.stubControllerComponents()
+    implicit val eC: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
+    implicit val headerCarrier: HeaderCarrier = HeaderCarrier()
+
+    def jsRequest(method: String, uri: String, jsonBody: JsValue): FakeRequest[JsValue] =
+      FakeRequest[JsValue](method, uri, authSessionHeaders, jsonBody).withSession(SessionKeys.authToken -> "Bearer XYZ")
+
+    def requestWithAuthSession(method: String, uri: String): FakeRequest[AnyContentAsEmpty.type] =
+      FakeRequest(method, uri)
+        .withHeaders(authSessionHeaders)
+        .withSession(SessionKeys.authToken -> "Bearer XYZ")
+
+    val controller = new CountryByCountryController(
+      mockAuthService,
+      mockCbcService,
+      controllerComponents
+    )
+
+    // cbc service mock
+    def expectGetCbcSubscriptionRecord(
+      maybeRecord: Option[CbcSubscriptionRecord]
+    ): CallHandler3[CbcId, String, ExecutionContext, Future[Option[CbcSubscriptionRecord]]] =
+      (mockCbcService
+        .getCbcSubscriptionRecord(_: CbcId, _: String)(_: ExecutionContext))
+        .expects(*, *, *)
+        .returns(Future.successful(maybeRecord))
+
+    val validCbcStr: String = cbcId("fort").value
+    val email = "test@foo.uk"
+    val acknowledgementReference: String = UUID.randomUUID().toString.replace("-", "")
+
+    val validPayload: JsValue =
+      Json.toJson(
+        DisplaySubscriptionForCbCRequestPayload(
+          DisplaySubscriptionForCBCRequest(
+            CbCRequestCommon("CBC", None, LocalDateTime.now(), acknowledgementReference),
+            CbCRequestDetail(IDNumber = validCbcStr)
+          )
+        )
+      )
+
+  }
+
+  "POST /dac6/dct50d/v1 (display subscription for cbc)" should {
+    "return 200 with country by country subscription details" in new TestScope {
+      //given
+      val expectedRecord: CbcSubscriptionRecord =
+        CbcSubscriptionRecord
+          .seed("foo")
+          .withCbcId(validCbcStr)
+          .withEmail(email)
+
+      expectGetCbcSubscriptionRecord(Some(expectedRecord))
+
+      //when
+      val result: Future[Result] =
+        controller.displaySubscriptionForCbC.apply(
+          jsRequest("POST", "/dac6/dct50d/v1", validPayload)
+        )
+      //then
+      status(result) shouldBe 200
+    }
+
+    "return NOT_FOUND with error response if no record" in new TestScope {
+      //given
+      expectGetCbcSubscriptionRecord(None)
+
+      //when
+      val result: Future[Result] =
+        controller.displaySubscriptionForCbC.apply(
+          jsRequest("POST", "/dac6/dct50d/v1", validPayload)
+        )
+      //then
+      status(result) shouldBe 404
+    }
+
+    "throw BadRequestException if bad payload" in new TestScope {
+      val result: Future[Result] =
+        controller.displaySubscriptionForCbC.apply(
+          jsRequest(
+            "POST",
+            "/dac6/dct50d/v1",
+            Json.parse("""{"displaySubscriptionForCBCRequest": {} }""".stripMargin)
+          )
+        )
+
+      //then
+      a[BadRequestException] shouldBe thrownBy(
+        status(result) shouldBe 400
+      )
+    }
+
+    "return unauthorised without session" in new TestScope {
+      // given no auth session headers, when request
+      val result: Future[Result] =
+        controller.displaySubscriptionForCbC.apply(
+          FakeRequest("POST", "/dac6/dct50d/v1", FakeHeaders(), Json.parse("""{"no": "doesn't matter"}"""))
+        )
+
+      status(result) shouldBe 401
+    }
+  }
+
+}

--- a/test/uk/gov/hmrc/agentsexternalstubs/controllers/admin/KnownFactsControllerSpec.scala
+++ b/test/uk/gov/hmrc/agentsexternalstubs/controllers/admin/KnownFactsControllerSpec.scala
@@ -14,13 +14,14 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.agentsexternalstubs.controllers
+package uk.gov.hmrc.agentsexternalstubs.controllers.admin
 
 import org.scalamock.scalatest.MockFactory
 import play.api.libs.json.{JsValue, Json}
 import play.api.mvc.{AnyContentAsEmpty, ControllerComponents, Result}
-import play.api.test.{FakeHeaders, FakeRequest, Helpers}
-import uk.gov.hmrc.agentsexternalstubs.models.{AuthenticatedSession, EnrolmentKey, KnownFact, KnownFacts, User}
+import play.api.test.{FakeRequest, Helpers}
+import uk.gov.hmrc.agentsexternalstubs.models.admin.User
+import uk.gov.hmrc.agentsexternalstubs.models.{EnrolmentKey, KnownFact, KnownFacts}
 import uk.gov.hmrc.agentsexternalstubs.repository.{KnownFactsRepository, UsersRepository}
 import uk.gov.hmrc.agentsexternalstubs.services.AuthenticationService
 import uk.gov.hmrc.agentsexternalstubs.support.BaseUnitSpec
@@ -37,16 +38,6 @@ class KnownFactsControllerSpec extends BaseUnitSpec with MockFactory {
     val controllerComponents: ControllerComponents = Helpers.stubControllerComponents()
     implicit val eC: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
     implicit val headerCarrier: HeaderCarrier = HeaderCarrier()
-
-    val authSessionHeaders: FakeHeaders = FakeHeaders(
-      Seq(
-        AuthenticatedSession.TAG_SESSION_ID    -> "session123",
-        AuthenticatedSession.TAG_USER_ID       -> "userId",
-        AuthenticatedSession.TAG_AUTH_TOKEN    -> "good",
-        AuthenticatedSession.TAG_PROVIDER_TYPE -> "off",
-        AuthenticatedSession.TAG_PLANET_ID     -> "earth467"
-      )
-    )
 
     def jsRequest(method: String, uri: String, jsonBody: JsValue): FakeRequest[JsValue] =
       FakeRequest[JsValue](method, uri, authSessionHeaders, jsonBody).withSession(SessionKeys.authToken -> "Bearer XYZ")
@@ -140,7 +131,7 @@ class KnownFactsControllerSpec extends BaseUnitSpec with MockFactory {
       //given
       expectUpsertKnownFacts
 
-      val jsonPayload = Json.parse(s"""
+      val jsonPayload: JsValue = Json.parse(s"""
         |{ "enrolmentKey": "$enrolmentKeyStr",
         |  "identifiers": [
         |   {

--- a/test/uk/gov/hmrc/agentsexternalstubs/models/AgencyDataAssemblerSpec.scala
+++ b/test/uk/gov/hmrc/agentsexternalstubs/models/AgencyDataAssemblerSpec.scala
@@ -17,6 +17,7 @@
 package uk.gov.hmrc.agentsexternalstubs.models
 
 import uk.gov.hmrc.agentsexternalstubs.controllers.datagen.AgencyDataAssembler
+import uk.gov.hmrc.agentsexternalstubs.models.admin._
 import uk.gov.hmrc.agentsexternalstubs.support.BaseUnitSpec
 
 class AgencyDataAssemblerSpec extends BaseUnitSpec {

--- a/test/uk/gov/hmrc/agentsexternalstubs/models/AuthoriseRequestSpec.scala
+++ b/test/uk/gov/hmrc/agentsexternalstubs/models/AuthoriseRequestSpec.scala
@@ -19,6 +19,7 @@ package uk.gov.hmrc.agentsexternalstubs.models
 import play.api.libs.json.Json
 import uk.gov.hmrc.agentsexternalstubs.support.BaseUnitSpec
 import org.mockito.Mockito._
+import uk.gov.hmrc.agentsexternalstubs.models.admin.AG
 import uk.gov.hmrc.domain.Nino
 
 class AuthoriseRequestSpec extends BaseUnitSpec {

--- a/test/uk/gov/hmrc/agentsexternalstubs/models/admin/GroupSanitizerSpec.scala
+++ b/test/uk/gov/hmrc/agentsexternalstubs/models/admin/GroupSanitizerSpec.scala
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.agentsexternalstubs.models
+package uk.gov.hmrc.agentsexternalstubs.models.admin
 
+import uk.gov.hmrc.agentsexternalstubs.models.Enrolment
 import uk.gov.hmrc.agentsexternalstubs.support.BaseUnitSpec
 
 class GroupSanitizerSpec extends BaseUnitSpec {

--- a/test/uk/gov/hmrc/agentsexternalstubs/models/admin/GroupUsersValidatorSpec.scala
+++ b/test/uk/gov/hmrc/agentsexternalstubs/models/admin/GroupUsersValidatorSpec.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.agentsexternalstubs.models
+package uk.gov.hmrc.agentsexternalstubs.models.admin
 
 import cats.data.Validated.Valid
 import uk.gov.hmrc.agentsexternalstubs.support.BaseUnitSpec

--- a/test/uk/gov/hmrc/agentsexternalstubs/models/admin/GroupValidatorSpec.scala
+++ b/test/uk/gov/hmrc/agentsexternalstubs/models/admin/GroupValidatorSpec.scala
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.agentsexternalstubs.models
+package uk.gov.hmrc.agentsexternalstubs.models.admin
 
 import org.scalatest.Inspectors._
+import uk.gov.hmrc.agentsexternalstubs.models.{Enrolment, Generator, Services}
 import uk.gov.hmrc.agentsexternalstubs.support.{BaseUnitSpec, ValidatedMatchers}
 
 class GroupValidatorSpec extends BaseUnitSpec with ValidatedMatchers {

--- a/test/uk/gov/hmrc/agentsexternalstubs/models/admin/UserSanitizerSpec.scala
+++ b/test/uk/gov/hmrc/agentsexternalstubs/models/admin/UserSanitizerSpec.scala
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.agentsexternalstubs.models
+package uk.gov.hmrc.agentsexternalstubs.models.admin
 
-import uk.gov.hmrc.domain.Nino
 import uk.gov.hmrc.agentsexternalstubs.support.BaseUnitSpec
+import uk.gov.hmrc.domain.Nino
 
 import java.time.LocalDate
 

--- a/test/uk/gov/hmrc/agentsexternalstubs/models/admin/UserValidatorSpec.scala
+++ b/test/uk/gov/hmrc/agentsexternalstubs/models/admin/UserValidatorSpec.scala
@@ -14,11 +14,10 @@
  * limitations under the License.
  */
 
-package uk.gov.hmrc.agentsexternalstubs.models
+package uk.gov.hmrc.agentsexternalstubs.models.admin
 
+import uk.gov.hmrc.agentsexternalstubs.support.{BaseUnitSpec, ValidatedMatchers}
 import uk.gov.hmrc.domain.Nino
-import uk.gov.hmrc.agentsexternalstubs.support.BaseUnitSpec
-import uk.gov.hmrc.agentsexternalstubs.support.ValidatedMatchers
 
 import java.time.LocalDate
 

--- a/test/uk/gov/hmrc/agentsexternalstubs/support/BaseUnitSpec.scala
+++ b/test/uk/gov/hmrc/agentsexternalstubs/support/BaseUnitSpec.scala
@@ -21,12 +21,23 @@ import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpecLike
 import play.api.mvc.Result
-import play.api.test.Helpers
+import play.api.test.{FakeHeaders, Helpers}
 import play.api.test.Helpers.defaultAwaitTimeout
+import uk.gov.hmrc.agentsexternalstubs.models.AuthenticatedSession
 
 import scala.concurrent.Future
 
 trait BaseUnitSpec extends AnyWordSpecLike with Matchers with OptionValues with ScalaFutures {
+  val authSessionHeaders: FakeHeaders = FakeHeaders(
+    Seq(
+      AuthenticatedSession.TAG_SESSION_ID    -> "session123",
+      AuthenticatedSession.TAG_USER_ID       -> "userId",
+      AuthenticatedSession.TAG_AUTH_TOKEN    -> "good",
+      AuthenticatedSession.TAG_PROVIDER_TYPE -> "off",
+      AuthenticatedSession.TAG_PLANET_ID     -> "earth467"
+    )
+  )
+
   // the following is a collection of useful methods that should minimise
   // the changes required when migrating away from hmrctest, which is now deprecated.
   def status(result: Result): Int = result.header.status


### PR DESCRIPTION
not sure if I should also move Auth/SignIn - there are some models in the controller dir that probably should be moved, but the models folder has lots of stuff in it as it is, so I've left them for now. RecordsController have also left out as we have data gen endpoints unique to a service there

idea is to separate the core admin functionality (eg. users, setting up a test planet) from stubs of HoD's or external services we add