### PR TITLE
APB-9567 support a non uk country for CiD address

### DIFF
--- a/app/uk/gov/hmrc/agentsexternalstubs/controllers/CitizenDetailsStubController.scala
+++ b/app/uk/gov/hmrc/agentsexternalstubs/controllers/CitizenDetailsStubController.scala
@@ -209,7 +209,11 @@ object CitizenDetailsStubController {
             line2 = a.line2,
             line3 = a.line3,
             postcode = a.postcode,
-            country = a.countryCode.map { case "GB" => "GREAT BRITAIN"; case cc => cc }
+            country = a.countryCode.map {
+              case "GB" => "GREAT BRITAIN"
+              case "PG" => "PAPUA NEW GUINEA"
+              case cc => cc 
+            }
           )
         )
       )


### PR DESCRIPTION
Adding `PG` mapping to Citizen Details responses will enable us to test stubbed users with a non-UK address e.g. to prove the known fact scenarios using overseas clients for ITSA invitations

`PG (Papua New Guinea)` is nominal and could be any country as long as it's not UK.