### PR TITLE
APB-10828 Removed verifiers for ES2 and ES3 response

### DIFF
--- a/app/uk/gov/hmrc/agentsexternalstubs/controllers/EnrolmentStoreProxyStubController.scala
+++ b/app/uk/gov/hmrc/agentsexternalstubs/controllers/EnrolmentStoreProxyStubController.scala
@@ -19,11 +19,11 @@ package uk.gov.hmrc.agentsexternalstubs.controllers
 import cats.data.Validated
 import play.api.libs.json._
 import play.api.mvc.{Action, AnyContent, ControllerComponents, Result}
-import uk.gov.hmrc.agentsexternalstubs.models.identifiers._
 import uk.gov.hmrc.agentsexternalstubs.controllers.EnrolmentStoreProxyStubController.SetKnownFactsRequest.Legacy
 import uk.gov.hmrc.agentsexternalstubs.controllers.EnrolmentStoreProxyStubController._
 import uk.gov.hmrc.agentsexternalstubs.models.Validator.{Validator, check, checkProperty}
 import uk.gov.hmrc.agentsexternalstubs.models._
+import uk.gov.hmrc.agentsexternalstubs.models.identifiers._
 import uk.gov.hmrc.agentsexternalstubs.repository.{DuplicateUserException, KnownFactsRepository}
 import uk.gov.hmrc.agentsexternalstubs.services.{AuthenticationService, EnrolmentAlreadyExists, GroupsService, UsersService}
 import uk.gov.hmrc.auth.core.UnsupportedCredentialRole
@@ -239,9 +239,6 @@ class EnrolmentStoreProxyStubController @Inject() (
           notFoundF("INVALID_GROUP_ID")
         case Some(group) =>
           val principal = `type` == "principal"
-          val getKnownFacts: EnrolmentKey => Future[Option[KnownFacts]] =
-            if (principal) knownFactsRepository.findByEnrolmentKey(_, planetId)
-            else _ => Future.successful(None)
           val startRecord = `start-record`.getOrElse(1)
           def assignedEnrolments(user: User) = if (principal) user.assignedPrincipalEnrolments
           else user.assignedDelegatedEnrolments
@@ -249,13 +246,12 @@ class EnrolmentStoreProxyStubController @Inject() (
             .filter(e => service.forall(_ == e.key))
             .filter(e => assignedToUser.forall(user => e.toEnrolmentKey.exists(assignedEnrolments(user).contains(_))))
             .slice(startRecord - 1, startRecord - 1 + `max-records`.getOrElse(1000))
-          Future
-            .sequence(enrolments.map(_.toEnrolmentKey).collect { case Some(x) => x }.map(getKnownFacts))
-            .map(_.collect { case Some(x) => x })
-            .map(knownFacts => GetUserEnrolmentsResponse.from(startRecord, enrolments, knownFacts))
-            .map { response =>
-              if (response.totalRecords == 0) NoContent else Ok(Json.toJson(response))
-            }
+
+          val response = GetUserEnrolmentsResponse.from(startRecord, enrolments)
+          Future.successful {
+            if (response.totalRecords == 0) NoContent
+            else Ok(Json.toJson(response))
+          }
       }
     }
 
@@ -532,7 +528,7 @@ object EnrolmentStoreProxyStubController {
 
     object Enrolment {
 
-      def from(e: uk.gov.hmrc.agentsexternalstubs.models.Enrolment, kf: Option[KnownFacts]): Enrolment = Enrolment(
+      def from(e: uk.gov.hmrc.agentsexternalstubs.models.Enrolment): Enrolment = Enrolment(
         service = e.key,
         state = e.state,
         friendlyName = e.friendlyName.getOrElse(""),
@@ -541,23 +537,21 @@ object EnrolmentStoreProxyStubController {
         enrolmentDate = Option(randomDateTimeInTheLastFiveYears),
         enrolmentTokenExpiryDate = None,
         identifiers = e.identifiers
-          .getOrElse(Seq.empty) ++ kf.map(_.verifiers.map(v => Identifier(v.key, v.value))).getOrElse(Seq.empty)
+          .getOrElse(Seq.empty)
       )
     }
 
     def from(
       startRecord: Int,
-      enrolments: Seq[uk.gov.hmrc.agentsexternalstubs.models.Enrolment],
-      knownFacts: Seq[KnownFacts]
+      enrolments: Seq[uk.gov.hmrc.agentsexternalstubs.models.Enrolment]
     ): GetUserEnrolmentsResponse = {
-      val ee =
+      val responseEnrolment =
         enrolments
-          .map(e => (e, knownFacts.find(kf => e.toEnrolmentKeyTag.contains(kf.enrolmentKey.tag))))
-          .map { case (e, kf) => Enrolment.from(e, kf) }
+          .map(e => Enrolment.from(e))
       GetUserEnrolmentsResponse(
         startRecord = startRecord,
-        totalRecords = ee.size,
-        enrolments = ee
+        totalRecords = responseEnrolment.size,
+        enrolments = responseEnrolment
       )
     }
 


### PR DESCRIPTION
The stubs for ES2 and ES3 seem to be set up to return all known facts (identifiers and verifiers) for the principal enrolments it finds, instead of just identifiers. 
This doesn't seem to match the real API behaviour which always only returns the identifiers.