### PR TITLE
APB-11869 - Fix for business address that is too long for validation

### DIFF
--- a/app/uk/gov/hmrc/agentsexternalstubs/models/Generator.scala
+++ b/app/uk/gov/hmrc/agentsexternalstubs/models/Generator.scala
@@ -201,8 +201,11 @@ object Generator
   case class Address(street: String, town: String, postcode: String)
   lazy val addressGen: Gen[Address] = ukAddress
     .map {
-      case street :: town :: postcode :: Nil => Address(street.replaceAll("[^A-Za-z0-9 /s //.]", ""), town, postcode)
-      case _                                 => throw new GeneratorException("Cannot map address")
+      case street :: town :: postcode :: Nil =>
+        val cleanStreet = street.replaceAll("""[^A-Za-z0-9 .,()!@-]""", "").trim
+        val cleanTown = town.replaceAll("""[^A-Za-z0-9 .,()!@-]""", "").trim
+        Address(cleanStreet, cleanTown, postcode)
+      case _ => throw new GeneratorException("Cannot map address")
     }
 
   def address(userId: String): Address = addressGen.seeded(userId).get
@@ -213,7 +216,12 @@ object Generator
       ukAddress
         .map {
           case street :: town :: postcode :: Nil =>
-            Address4Lines35(street.take(35).replace(";", " "), s"The $s House".take(35), town.take(35), postcode)
+            Address4Lines35(
+              street.take(35).replace(";", " ").trim,
+              s"The $s House".take(35).trim,
+              town.take(35).trim,
+              postcode
+            )
           case _ => throw new GeneratorException("Cannot map address")
         }
     )

--- a/app/uk/gov/hmrc/agentsexternalstubs/models/Generator.scala
+++ b/app/uk/gov/hmrc/agentsexternalstubs/models/Generator.scala
@@ -202,8 +202,8 @@ object Generator
   lazy val addressGen: Gen[Address] = ukAddress
     .map {
       case street :: town :: postcode :: Nil =>
-        val cleanStreet = street.replaceAll("""[^A-Za-z0-9 .,()!@-]""", "").trim
-        val cleanTown = town.replaceAll("""[^A-Za-z0-9 .,()!@-]""", "").trim
+        val cleanStreet = street.trim.replaceAll("""[^A-Za-z0-9 .,()!@-]""", "")
+        val cleanTown = town.trim.replaceAll("""[^A-Za-z0-9 .,()!@-]""", "")
         Address(cleanStreet, cleanTown, postcode)
       case _ => throw new GeneratorException("Cannot map address")
     }

--- a/app/uk/gov/hmrc/agentsexternalstubs/models/UserSanitizer.scala
+++ b/app/uk/gov/hmrc/agentsexternalstubs/models/UserSanitizer.scala
@@ -178,8 +178,8 @@ case class UserSanitizer(affinityGroup: Option[String]) extends RecordUtils[User
       case None =>
         Some(
           User.Address(
-            line1 = Some(newAddress.street.take(35).trim),
-            line2 = Some(newAddress.town.take(35).trim),
+            line1 = Some(newAddress.street.trim.take(35)),
+            line2 = Some(newAddress.town.trim.take(35)),
             postcode = Some(newAddress.postcode),
             countryCode = Some("GB")
           )
@@ -187,8 +187,8 @@ case class UserSanitizer(affinityGroup: Option[String]) extends RecordUtils[User
       case Some(address) =>
         Some(
           address.copy(
-            line1 = address.line1.map(_.take(35).trim).orElse(Some(newAddress.street.take(35).trim)),
-            line2 = address.line2.map(_.take(35).trim).orElse(Some(newAddress.town.take(35).trim)),
+            line1 = address.line1.map(_.take(35).trim).orElse(Some(newAddress.street.trim.take(35))),
+            line2 = address.line2.map(_.take(35).trim).orElse(Some(newAddress.town.trim.take(35))),
             postcode = UserValidator(affinityGroup)
               .postalCodeValidator(address.postcode)
               .fold(_ => None, _ => address.postcode)

--- a/app/uk/gov/hmrc/agentsexternalstubs/models/UserSanitizer.scala
+++ b/app/uk/gov/hmrc/agentsexternalstubs/models/UserSanitizer.scala
@@ -178,8 +178,8 @@ case class UserSanitizer(affinityGroup: Option[String]) extends RecordUtils[User
       case None =>
         Some(
           User.Address(
-            line1 = Some(newAddress.street.take(35)),
-            line2 = Some(newAddress.town.take(35)),
+            line1 = Some(newAddress.street.take(35).trim),
+            line2 = Some(newAddress.town.take(35).trim),
             postcode = Some(newAddress.postcode),
             countryCode = Some("GB")
           )
@@ -187,8 +187,8 @@ case class UserSanitizer(affinityGroup: Option[String]) extends RecordUtils[User
       case Some(address) =>
         Some(
           address.copy(
-            line1 = address.line1.map(_.take(35)).orElse(Some(newAddress.street.take(35))),
-            line2 = address.line2.map(_.take(35)).orElse(Some(newAddress.town.take(35))),
+            line1 = address.line1.map(_.take(35).trim).orElse(Some(newAddress.street.take(35).trim)),
+            line2 = address.line2.map(_.take(35).trim).orElse(Some(newAddress.town.take(35).trim)),
             postcode = UserValidator(affinityGroup)
               .postalCodeValidator(address.postcode)
               .fold(_ => None, _ => address.postcode)


### PR DESCRIPTION
agent-external-stubs is generating a business address that is too long for its respective field